### PR TITLE
feat: add crates.io metadata to contract Cargo.toml files

### DIFF
--- a/contracts/alert-registry/Cargo.toml
+++ b/contracts/alert-registry/Cargo.toml
@@ -3,6 +3,11 @@ name = "alert-registry"
 version = "0.1.0"
 edition = "2021"
 rust-version.workspace = true
+description = "Soroban smart contract for managing webhook alert configurations on Stellar"
+license = "Apache-2.0"
+repository = "https://github.com/Tx-wat/contracts"
+homepage = "https://github.com/Tx-wat/contracts"
+documentation = "https://docs.rs/alert-registry"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contracts/watcher-registry/Cargo.toml
+++ b/contracts/watcher-registry/Cargo.toml
@@ -3,6 +3,11 @@ name = "watcher-registry"
 version = "0.1.0"
 edition = "2021"
 rust-version.workspace = true
+description = "Soroban smart contract for managing authorized watcher addresses on Stellar"
+license = "Apache-2.0"
+repository = "https://github.com/Tx-wat/contracts"
+homepage = "https://github.com/Tx-wat/contracts"
+documentation = "https://docs.rs/watcher-registry"
 
 [lib]
 crate-type = ["cdylib", "rlib"]


### PR DESCRIPTION
This PR adds crates.io metadata to both contract `Cargo.toml` files, enabling `cargo add`-based consumption for downstream Rust projects.

## Changes

### alert-registry/Cargo.toml
- `description`: "Soroban smart contract for managing webhook alert configurations on Stellar"
- `license`: "Apache-2.0"
- `repository`: "https://github.com/Tx-wat/contracts"
- `homepage`: "https://github.com/Tx-wat/contracts"
- `documentation`: "https://docs.rs/alert-registry"

### watcher-registry/Cargo.toml
- `description`: "Soroban smart contract for managing authorized watcher addresses on Stellar"
- `license`: "Apache-2.0"
- `repository`: "https://github.com/Tx-wat/contracts"
- `homepage`: "https://github.com/Tx-wat/contracts"
- `documentation`: "https://docs.rs/watcher-registry"

Closes #84
Closes #86
Closes #85
Closes #83