### PR TITLE
feat: add WASM Hash column to DEPLOYMENTS.md

### DIFF
--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -41,38 +41,46 @@ jobs:
           echo "$OUTPUT"
           ALERT_ID=$(echo "$OUTPUT" | grep "Alert Registry deployed:" | awk '{print $NF}')
           WATCHER_ID=$(echo "$OUTPUT" | grep "Watcher Registry deployed:" | awk '{print $NF}')
+          ALERT_HASH=$(echo "$OUTPUT" | grep "Alert Registry:" | tail -1 | awk '{print $NF}')
+          WATCHER_HASH=$(echo "$OUTPUT" | grep "Watcher Registry:" | tail -1 | awk '{print $NF}')
           echo "alert_id=$ALERT_ID" >> "$GITHUB_OUTPUT"
           echo "watcher_id=$WATCHER_ID" >> "$GITHUB_OUTPUT"
+          echo "alert_hash=$ALERT_HASH" >> "$GITHUB_OUTPUT"
+          echo "watcher_hash=$WATCHER_HASH" >> "$GITHUB_OUTPUT"
 
       - name: Update DEPLOYMENTS.md
         env:
           ALERT_ID: ${{ steps.deploy.outputs.alert_id }}
           WATCHER_ID: ${{ steps.deploy.outputs.watcher_id }}
+          ALERT_HASH: ${{ steps.deploy.outputs.alert_hash }}
+          WATCHER_HASH: ${{ steps.deploy.outputs.watcher_hash }}
           TAG: ${{ github.ref_name }}
         run: |
           python3 - <<'EOF'
           import os, re
           from datetime import datetime, timezone
 
-          alert_id  = os.environ["ALERT_ID"]
+          alert_id   = os.environ["ALERT_ID"]
           watcher_id = os.environ["WATCHER_ID"]
-          tag       = os.environ["TAG"]
-          date      = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+          alert_hash   = os.environ["ALERT_HASH"]
+          watcher_hash = os.environ["WATCHER_HASH"]
+          tag        = os.environ["TAG"]
+          date       = datetime.now(timezone.utc).strftime("%Y-%m-%d")
 
           text = open("DEPLOYMENTS.md").read()
 
-          # Replace contract addresses in the current-deployment table
-          text = re.sub(r"(Alert Registry \| )`[^`]+`", rf"\1`{alert_id}`", text)
-          text = re.sub(r"(Watcher Registry \| )`[^`]+`", rf"\1`{watcher_id}`", text)
+          # Replace contract addresses and WASM hashes in the current-deployment table
+          text = re.sub(r"(Alert Registry \| )`[^`]+`(\| )`[^`]+`", rf"\1`{alert_id}`\2`{alert_hash}`", text)
+          text = re.sub(r"(Watcher Registry \| )`[^`]+`(\| )`[^`]+`", rf"\1`{watcher_id}`\2`{watcher_hash}`", text)
 
           # Prepend new history rows before the placeholder row
           history_rows = (
-              f"| {date} | Alert Registry | `{alert_id}` | {tag} |\n"
-              f"| {date} | Watcher Registry | `{watcher_id}` | {tag} |\n"
+              f"| {date} | Alert Registry | `{alert_id}` | `{alert_hash}` | {tag} |\n"
+              f"| {date} | Watcher Registry | `{watcher_id}` | `{watcher_hash}` | {tag} |\n"
           )
           text = text.replace(
-              "| — | — | — | Initial placeholder |",
-              history_rows + "| — | — | — | Initial placeholder |",
+              "| — | — | — | — | Initial placeholder |",
+              history_rows + "| — | — | — | — | Initial placeholder |",
               1,
           )
 

--- a/DEPLOYMENTS.md
+++ b/DEPLOYMENTS.md
@@ -11,10 +11,10 @@ After running `scripts/deploy.sh`, replace the placeholder values with the print
 
 ## Stellar Testnet
 
-| Contract | Address |
-|---|---|
-| Alert Registry | `CDSO4GGZH7KBUQYKOIQDCMCFSRYEPOVDUX7Z4IB5TWNTLT2GDRKDQOYR` |
-| Watcher Registry | `CCSHRYACRNVSLC5NP3V2DL6LGID57TQT2TJXVUVXBBZX6SED6N3F7X6J` |
+| Contract | Address | WASM Hash |
+|---|---|---|
+| Alert Registry | `CDSO4GGZH7KBUQYKOIQDCMCFSRYEPOVDUX7Z4IB5TWNTLT2GDRKDQOYR` | `TODO` |
+| Watcher Registry | `CCSHRYACRNVSLC5NP3V2DL6LGID57TQT2TJXVUVXBBZX6SED6N3F7X6J` | `TODO` |
 
 Deployed and initialized on 2026-08-17. Verified end to end on-chain:
 `register_alert` → `get_alert`, then a full `propose_webhook` → `confirm_webhook`
@@ -38,10 +38,10 @@ rotation emitting `alert.wh_prop` and `alert.wh_conf`.
 
 ## Stellar Mainnet
 
-| Contract | Address |
-|---|---|
-| Alert Registry | `CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX` |
-| Watcher Registry | `CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX` |
+| Contract | Address | WASM Hash |
+|---|---|---|
+| Alert Registry | `CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX` | `TODO` |
+| Watcher Registry | `CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX` | `TODO` |
 
 ### Mainnet Network Details
 
@@ -62,8 +62,8 @@ rotation emitting `alert.wh_prop` and `alert.wh_conf`.
    ```bash
    bash scripts/deploy.sh
    ```
-2. Copy the contract addresses printed at the end of the script output.
-3. Replace the corresponding `CXXX...` placeholders in the table above.
+2. Copy the contract addresses and WASM hashes printed at the end of the script output.
+3. Replace the corresponding `CXXX...` placeholders and `TODO` hashes in the table above.
 4. Commit the update:
    ```bash
    git add DEPLOYMENTS.md
@@ -74,6 +74,6 @@ rotation emitting `alert.wh_prop` and `alert.wh_conf`.
 
 ## Deployment History
 
-| Date | Network | Contract | Address | Notes |
-|---|---|---|---|---|
-| — | — | — | — | Initial placeholder |
+| Date | Network | Contract | Address | WASM Hash | Notes |
+|---|---|---|---|---|---|
+| — | — | — | — | — | Initial placeholder |

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -89,7 +89,14 @@ stellar contract invoke \
   -- initialize \
   --admin "$ADMIN_ADDRESS"
 
+ALERT_HASH=$(sha256sum "$ALERT_WASM" | awk '{print $1}')
+WATCHER_HASH=$(sha256sum "$WATCHER_WASM" | awk '{print $1}')
+
 echo ""
 echo "==> Deployment complete ($NETWORK). Update DEPLOYMENTS.md with:"
 echo "    Alert Registry:   $ALERT_ID"
 echo "    Watcher Registry: $WATCHER_ID"
+echo ""
+echo "==> WASM hashes (copy into DEPLOYMENTS.md):"
+echo "    Alert Registry:   $ALERT_HASH"
+echo "    Watcher Registry: $WATCHER_HASH"


### PR DESCRIPTION
This PR adds a "WASM Hash" column to both deployment tables in `DEPLOYMENTS.md`, providing a persisted reference hash for verification independent of re-running the deploy script.

## Changes

### DEPLOYMENTS.md
- Added `WASM Hash` column to the Stellar Testnet table (with `TODO` placeholders for backfill)
- Added `WASM Hash` column to the Stellar Mainnet table (with `TODO` placeholders)
- Added `WASM Hash` column to the Deployment History table
- Updated "How to Update This File" instructions to mention copying WASM hashes

### scripts/deploy.sh
- Added sha256 computation of optimized WASM files after deployment
- Prints WASM hashes alongside contract addresses for easy copy-paste into DEPLOYMENTS.md

### .github/workflows/deploy-testnet.yml
- Updated deploy step to extract WASM hashes from deploy script output
- Updated Python script to replace WASM hashes in both the current-deployment and history tables

Closes #91
Closes #92
Closes #93
Closes #94