### PR TITLE
fix: automated events doc check, load cost tests, auth audit, and incident runbook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,10 @@ jobs:
       - name: Format check
         run: cargo fmt --check
 
+      # Issue #111 — Verify events documentation matches source emissions
+      - name: Check events documentation
+        run: bash scripts/check-events-doc.sh
+
   # Issue #105 — Dependency vulnerability scanning.
   #
   # cargo-audit's current release needs a newer rustc than the toolchain pinned

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test lint fmt deploy-testnet bindings clean
+.PHONY: build test lint fmt check-events deploy-testnet bindings clean
 
 build:
 	cargo build --release --target wasm32-unknown-unknown --locked -p alert-registry -p watcher-registry
@@ -11,6 +11,9 @@ lint:
 
 fmt:
 	cargo fmt --all
+
+check-events:
+	bash scripts/check-events-doc.sh
 
 deploy-testnet:
 	bash scripts/deploy.sh

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -46,7 +46,19 @@ The following are **out of scope**:
 - Stellar protocol-level vulnerabilities (report to the [Stellar Development Foundation](https://stellar.org/bug-bounty))
 - Issues in off-chain infrastructure not part of this repository
 
+## Incident Response & Operator Runbook
+
+In the event of a suspected or confirmed compromise of an administrative private key, operators should immediately follow the step-by-step procedures outlined in the [Incident Response Runbook](docs/incident-response.md):
+
+* **Immediate containment actions** (revoking admin privileges via `remove_admin` or `transfer_admin`)
+* **State audit & remediation** (purging unauthorized watchers, restoring watcher gating, validating per-owner limits)
+* **Stakeholder notification procedures** for downstream watcher nodes and alert owners
+* **Post-incident review and key hardening**
+
+See [`docs/incident-response.md`](docs/incident-response.md) for full operational guidance.
+
 ## Contact
 
 Maintainer: Emmanuel Chukwunyere — emmanuelanalaba@gmail.com  
 Organization: [Tx-wat](https://github.com/Tx-wat)
+

--- a/contracts/alert-registry/src/lib.rs
+++ b/contracts/alert-registry/src/lib.rs
@@ -2455,6 +2455,200 @@ mod tests {
         client.remove_alert_by_admin(&admin, &id);
     }
 
+    #[test]
+    #[should_panic(expected = "Error(Auth, InvalidAction)")]
+    fn test_set_watcher_registry_requires_auth() {
+        let env = Env::default();
+        let contract_id = env.register(AlertRegistry, ());
+        let client = AlertRegistryClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        env.mock_all_auths();
+        client.initialize(&admin);
+        let watcher_registry = Address::generate(&env);
+        env.set_auths(&[]);
+        client.set_watcher_registry(&admin, &watcher_registry);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Auth, InvalidAction)")]
+    fn test_propose_webhook_requires_auth() {
+        let env = Env::default();
+        let contract_id = env.register(AlertRegistry, ());
+        let client = AlertRegistryClient::new(&env, &contract_id);
+        let owner = Address::generate(&env);
+        let target = Address::generate(&env);
+        env.mock_all_auths();
+        let id =
+            client.register_alert(&owner, &target, &str(&env, "A"), &hash64(&env), &vec![&env]);
+        env.set_auths(&[]);
+        client.propose_webhook(&owner, &id, &hash64c(&env, 'p'));
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Auth, InvalidAction)")]
+    fn test_confirm_webhook_requires_auth() {
+        let env = Env::default();
+        let contract_id = env.register(AlertRegistry, ());
+        let client = AlertRegistryClient::new(&env, &contract_id);
+        let owner = Address::generate(&env);
+        let target = Address::generate(&env);
+        env.mock_all_auths();
+        let id =
+            client.register_alert(&owner, &target, &str(&env, "A"), &hash64(&env), &vec![&env]);
+        client.propose_webhook(&owner, &id, &hash64c(&env, 'p'));
+        env.set_auths(&[]);
+        client.confirm_webhook(&owner, &id);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Auth, InvalidAction)")]
+    fn test_renew_alert_ttl_requires_auth() {
+        let env = Env::default();
+        let contract_id = env.register(AlertRegistry, ());
+        let client = AlertRegistryClient::new(&env, &contract_id);
+        let owner = Address::generate(&env);
+        let target = Address::generate(&env);
+        env.mock_all_auths();
+        let id =
+            client.register_alert(&owner, &target, &str(&env, "A"), &hash64(&env), &vec![&env]);
+        env.set_auths(&[]);
+        client.renew_alert_ttl(&owner, &id);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Auth, InvalidAction)")]
+    fn test_update_label_requires_auth() {
+        let env = Env::default();
+        let contract_id = env.register(AlertRegistry, ());
+        let client = AlertRegistryClient::new(&env, &contract_id);
+        let owner = Address::generate(&env);
+        let target = Address::generate(&env);
+        env.mock_all_auths();
+        let id =
+            client.register_alert(&owner, &target, &str(&env, "A"), &hash64(&env), &vec![&env]);
+        env.set_auths(&[]);
+        client.update_label(&owner, &id, &str(&env, "New Label"));
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Auth, InvalidAction)")]
+    fn test_deactivate_all_alerts_requires_auth() {
+        let env = Env::default();
+        let contract_id = env.register(AlertRegistry, ());
+        let client = AlertRegistryClient::new(&env, &contract_id);
+        let owner = Address::generate(&env);
+        let target = Address::generate(&env);
+        env.mock_all_auths();
+        client.register_alert(&owner, &target, &str(&env, "A"), &hash64(&env), &vec![&env]);
+        env.set_auths(&[]);
+        client.deactivate_all_alerts(&owner);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Auth, InvalidAction)")]
+    fn test_update_target_contract_requires_auth() {
+        let env = Env::default();
+        let contract_id = env.register(AlertRegistry, ());
+        let client = AlertRegistryClient::new(&env, &contract_id);
+        let owner = Address::generate(&env);
+        let target = Address::generate(&env);
+        let new_target = Address::generate(&env);
+        env.mock_all_auths();
+        let id =
+            client.register_alert(&owner, &target, &str(&env, "A"), &hash64(&env), &vec![&env]);
+        env.set_auths(&[]);
+        client.update_target_contract(&owner, &id, &new_target);
+    }
+
+    // ── Load & Scan-Cost Benchmarks (Issues #38, #39, #116) ───────────────────
+
+    /// Load test quantifying the O(N) full-scan cost of `get_alerts_modified_since` (#38).
+    /// Registers N alerts and benchmarks the CPU instruction cost of scanning the registry,
+    /// establishing an upper bound budget regression guard.
+    #[test]
+    fn test_load_get_alerts_modified_since_instruction_cost() {
+        const N: usize = 50;
+
+        let (env, client) = setup();
+        let owner = Address::generate(&env);
+        let target = Address::generate(&env);
+        let hash = hash64(&env);
+        let rules = vec![&env, str(&env, "rule:transfer")];
+
+        for i in 0..N {
+            let label = str(&env, "Alert");
+            client.register_alert(&owner, &target, &label, &hash, &rules);
+            // Stagger timestamps so every alert has a distinct updated_at
+            if i % 5 == 0 {
+                env.ledger().with_mut(|li| li.timestamp += 1);
+            }
+        }
+
+        // Measure scan instruction cost across all N alerts
+        let cpu_before = env.cost_estimate().budget().cpu_instruction_cost();
+        let modified = client.get_alerts_modified_since(&0u64);
+        let cpu_after = env.cost_estimate().budget().cpu_instruction_cost();
+        let scan_cost = cpu_after.saturating_sub(cpu_before);
+
+        assert_eq!(modified.len() as usize, N);
+        // Assert an upper bound regression guard on the scan cost for N=50
+        assert!(
+            scan_cost < 15_000_000,
+            "get_alerts_modified_since cost {scan_cost} exceeded upper bound 15M instructions"
+        );
+    }
+
+    /// Load test quantifying the repeated rescan cost in `assert_per_owner_limit` (#39).
+    /// Registers alerts with an active per-owner limit and benchmarks instruction growth,
+    /// asserting an upper bound regression guard.
+    #[test]
+    fn test_load_assert_per_owner_limit_instruction_cost() {
+        const LIMIT: u32 = 40;
+
+        let (env, client) = setup();
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+        client.set_per_owner_alert_limit(&admin, &LIMIT);
+
+        let owner = Address::generate(&env);
+        let target = Address::generate(&env);
+        let hash = hash64(&env);
+        let rules = vec![&env];
+
+        let mut first_reg_cost: u64 = 0;
+        let mut last_reg_cost: u64 = 0;
+
+        let total_cpu_before = env.cost_estimate().budget().cpu_instruction_cost();
+
+        for i in 0..LIMIT {
+            let label = str(&env, "LimitLoadAlert");
+            let before = env.cost_estimate().budget().cpu_instruction_cost();
+            client.register_alert(&owner, &target, &label, &hash, &rules);
+            let after = env.cost_estimate().budget().cpu_instruction_cost();
+            let cost = after.saturating_sub(before);
+
+            if i == 0 {
+                first_reg_cost = cost;
+            } else if i == LIMIT - 1 {
+                last_reg_cost = cost;
+            }
+        }
+
+        let total_cpu_after = env.cost_estimate().budget().cpu_instruction_cost();
+        let total_registration_cost = total_cpu_after.saturating_sub(total_cpu_before);
+
+        // Quantify that cost per registration includes the owner scan overhead
+        assert!(
+            first_reg_cost > 0 && last_reg_cost > 0,
+            "Registration costs must be non-zero"
+        );
+        // Assert an upper bound regression guard on total batch registration cost with limit checks
+        assert!(
+            total_registration_cost < 50_000_000,
+            "Total registration cost {total_registration_cost} exceeded upper bound 50M instructions"
+        );
+    }
+
     // #63 — ID monotonicity: each successive register_alert returns prev+1
     #[test]
     fn test_id_monotonicity() {

--- a/contracts/watcher-registry/src/lib.rs
+++ b/contracts/watcher-registry/src/lib.rs
@@ -1106,4 +1106,109 @@ mod tests {
         // At least two events emitted (remove + replace)
         assert!(env.events().all().len() >= 2);
     }
+
+    // ── Auth-failure tests (no mock_all_auths) ────────────────────────────────
+
+    #[test]
+    #[should_panic(expected = "Error(Auth, InvalidAction)")]
+    fn test_add_admin_requires_auth() {
+        let env = Env::default();
+        let contract_id = env.register(WatcherRegistry, ());
+        let client = WatcherRegistryClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let new_admin = Address::generate(&env);
+        env.mock_all_auths();
+        client.initialize(&admin);
+        env.set_auths(&[]);
+        client.add_admin(&admin, &new_admin);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Auth, InvalidAction)")]
+    fn test_remove_admin_requires_auth() {
+        let env = Env::default();
+        let contract_id = env.register(WatcherRegistry, ());
+        let client = WatcherRegistryClient::new(&env, &contract_id);
+        let admin1 = Address::generate(&env);
+        let admin2 = Address::generate(&env);
+        env.mock_all_auths();
+        client.initialize(&admin1);
+        client.add_admin(&admin1, &admin2);
+        env.set_auths(&[]);
+        client.remove_admin(&admin1, &admin2);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Auth, InvalidAction)")]
+    fn test_transfer_admin_requires_auth() {
+        let env = Env::default();
+        let contract_id = env.register(WatcherRegistry, ());
+        let client = WatcherRegistryClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let new_admin = Address::generate(&env);
+        env.mock_all_auths();
+        client.initialize(&admin);
+        env.set_auths(&[]);
+        client.transfer_admin(&admin, &new_admin);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Auth, InvalidAction)")]
+    fn test_register_watcher_requires_auth() {
+        let env = Env::default();
+        let contract_id = env.register(WatcherRegistry, ());
+        let client = WatcherRegistryClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let watcher = Address::generate(&env);
+        env.mock_all_auths();
+        client.initialize(&admin);
+        env.set_auths(&[]);
+        client.register_watcher(&admin, &watcher);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Auth, InvalidAction)")]
+    fn test_remove_watcher_requires_auth() {
+        let env = Env::default();
+        let contract_id = env.register(WatcherRegistry, ());
+        let client = WatcherRegistryClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let watcher = Address::generate(&env);
+        env.mock_all_auths();
+        client.initialize(&admin);
+        client.register_watcher(&admin, &watcher);
+        env.set_auths(&[]);
+        client.remove_watcher(&admin, &watcher);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Auth, InvalidAction)")]
+    fn test_replace_watcher_requires_auth() {
+        let env = Env::default();
+        let contract_id = env.register(WatcherRegistry, ());
+        let client = WatcherRegistryClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let old_watcher = Address::generate(&env);
+        let new_watcher = Address::generate(&env);
+        env.mock_all_auths();
+        client.initialize(&admin);
+        client.register_watcher(&admin, &old_watcher);
+        env.set_auths(&[]);
+        client.replace_watcher(&admin, &old_watcher, &new_watcher);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Auth, InvalidAction)")]
+    fn test_clear_all_watchers_requires_auth() {
+        let env = Env::default();
+        let contract_id = env.register(WatcherRegistry, ());
+        let client = WatcherRegistryClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let watcher = Address::generate(&env);
+        env.mock_all_auths();
+        client.initialize(&admin);
+        client.register_watcher(&admin, &watcher);
+        env.set_auths(&[]);
+        client.clear_all_watchers(&admin);
+    }
 }

--- a/docs/events.md
+++ b/docs/events.md
@@ -197,6 +197,20 @@ Emitted when a watcher address is de-authorised.
 
 ---
 
+### `watcher.replace`
+
+Emitted when an existing watcher address is atomically replaced with a new watcher address.
+
+| Field | Value |
+|---|---|
+| Topic 0 | `Symbol("watcher")` |
+| Topic 1 | `Symbol("replace")` |
+| Data | `(old_watcher: Address, new_watcher: Address)` |
+
+**Status:** ✅ implemented (`replace_watcher`)
+
+---
+
 ### `admin.init`
 
 Emitted when the watcher registry admin is first initialised.
@@ -207,7 +221,35 @@ Emitted when the watcher registry admin is first initialised.
 | Topic 1 | `Symbol("init")` |
 | Data | `(admin: Address)` |
 
-**Status:** 🔲 planned (`initialize`)
+**Status:** ✅ implemented (`initialize`)
+
+---
+
+### `admin.add`
+
+Emitted when a new admin is added to the admin set.
+
+| Field | Value |
+|---|---|
+| Topic 0 | `Symbol("admin")` |
+| Topic 1 | `Symbol("add")` |
+| Data | `(caller: Address, new_admin: Address)` |
+
+**Status:** ✅ implemented (`add_admin`)
+
+---
+
+### `admin.remove`
+
+Emitted when an admin is removed from the admin set.
+
+| Field | Value |
+|---|---|
+| Topic 0 | `Symbol("admin")` |
+| Topic 1 | `Symbol("remove")` |
+| Data | `(caller: Address, target_admin: Address)` |
+
+**Status:** ✅ implemented (`remove_admin`)
 
 ---
 

--- a/docs/incident-response.md
+++ b/docs/incident-response.md
@@ -1,0 +1,206 @@
+# Incident Response Runbook: Compromised Admin Key
+
+This runbook defines the emergency response procedure for operators of the **TxWatch** smart contracts (`AlertRegistry` and `WatcherRegistry`) in the event that an administrative private key is suspected or confirmed to be compromised.
+
+---
+
+## 1. Threat Model & Blast Radius
+
+Understanding what an attacker can and cannot do with a compromised admin key determines the containment strategy:
+
+### AlertRegistry
+* **Admin capabilities:**
+  * Rotate the admin key via `transfer_admin`.
+  * Update the per-owner alert limit via `set_per_owner_alert_limit`.
+  * Change the linked `WatcherRegistry` contract address via `set_watcher_registry`.
+  * Delete any alert from storage via `remove_alert_by_admin`.
+* **What an attacker CANNOT do:**
+  * Register new alerts under a user's address (requires user `owner.require_auth()`).
+  * Modify existing user alerts, rules, or webhook URLs (requires user `caller.require_auth()`).
+  * Impersonate alert owners.
+
+### WatcherRegistry
+* **Admin capabilities:**
+  * Add new admins to the admin set via `add_admin`.
+  * Remove admins from the admin set via `remove_admin`.
+  * Overwrite the entire admin set with a single key via `transfer_admin`.
+  * Authorize watcher nodes via `register_watcher`.
+  * Deauthorize watcher nodes via `remove_watcher`, `replace_watcher`, or `clear_all_watchers`.
+* **What an attacker CANNOT do:**
+  * Remove the last remaining admin (prevented on-chain by `ContractError::LastAdmin`).
+  * Forge cryptographic signatures of watcher nodes.
+
+---
+
+## 2. Phase 1: Detection & Signal Identification
+
+An admin key compromise may be detected through several signals:
+
+1. **On-Chain Event Alerts:**
+   * `AlertRegistry`:
+     * `("admin", "transfer")` — emitted whenever `transfer_admin` is executed.
+     * `("alert", "remove")` — emitted when `remove_alert_by_admin` deletes an alert.
+   * `WatcherRegistry`:
+     * `("admin", "init")`, `("admin", "add")`, `("admin", "remove")`, `("admin", "transfer")`.
+     * `("watcher", "register")`, `("watcher", "remove")`, `("watcher", "replace")`.
+2. **Off-Chain Telemetry Anomalies:**
+   * Watcher nodes reporting unexpected deauthorization or inability to read gated alert queries (`ContractError::NotAWatcher`).
+   * Alert owners reporting sudden deletion of their configured alerts.
+3. **Out-of-Band Disclosures:**
+   * Secret leak detected in CI logs, developer environment, or repository.
+   * Host machine or key management service breach.
+
+---
+
+## 3. Phase 2: Immediate Containment
+
+Speed is critical. Containment must happen before an attacker transfers admin rights to an unrecoverable address or disrupts operations.
+
+```mermaid
+flowchart TD
+    A["Detection: Compromised Admin Key"] --> B{"Which Contract?"}
+    B -->|"WatcherRegistry"| C{"Multi-Admin Active?"}
+    C -->|"Yes (Recommended)"| D["Uncompromised Co-Admin calls remove_admin(compromised_key)"]
+    C -->|"No (Sole Admin)"| E["Immediately call transfer_admin(compromised_key, secure_key)"]
+    B -->|"AlertRegistry"| F["Immediately call transfer_admin(compromised_key, secure_key)"]
+    D --> G["Verify Admin State"]
+    E --> G
+    F --> G
+    G --> H["Audit & Remediate Registry State"]
+    H --> I["Notify Watchers & Alert Owners"]
+    I --> J["Post-Mortem & Key Hardening"]
+```
+
+### Action 2.1: WatcherRegistry Containment (Multi-Admin Set)
+If multi-admin is configured, any uncompromised co-admin can immediately revoke the compromised key without requiring the compromised key's signature:
+
+```bash
+# Using Stellar CLI as an uncompromised admin:
+stellar contract invoke \
+  --id <WATCHER_REGISTRY_CONTRACT_ID> \
+  --source-account <UNCOMPROMISED_ADMIN_SECRET> \
+  --network <NETWORK> \
+  -- \
+  remove_admin \
+  --caller <UNCOMPROMISED_ADMIN_ADDRESS> \
+  --target_admin <COMPROMISED_ADMIN_ADDRESS>
+```
+
+### Action 2.2: AlertRegistry (or Sole Admin WatcherRegistry) Rotation
+If the compromised key is the sole admin, rotate immediately to a clean cold storage address or multisig contract:
+
+```bash
+# Rotate AlertRegistry admin
+stellar contract invoke \
+  --id <ALERT_REGISTRY_CONTRACT_ID> \
+  --source-account <COMPROMISED_ADMIN_SECRET> \
+  --network <NETWORK> \
+  -- \
+  transfer_admin \
+  --admin <COMPROMISED_ADMIN_ADDRESS> \
+  --new_admin <NEW_SECURE_ADMIN_ADDRESS>
+```
+
+```bash
+# Rotate WatcherRegistry admin (if sole admin)
+stellar contract invoke \
+  --id <WATCHER_REGISTRY_CONTRACT_ID> \
+  --source-account <COMPROMISED_ADMIN_SECRET> \
+  --network <NETWORK> \
+  -- \
+  transfer_admin \
+  --admin <COMPROMISED_ADMIN_ADDRESS> \
+  --new_admin <NEW_SECURE_ADMIN_ADDRESS>
+```
+
+---
+
+## 4. Phase 3: Verification of Rotation
+
+Confirm on-chain that the compromised key has been completely stripped of administrative privileges:
+
+```bash
+# Check AlertRegistry admin
+stellar contract invoke \
+  --id <ALERT_REGISTRY_CONTRACT_ID> \
+  --network <NETWORK> \
+  -- \
+  get_admin
+
+# Check WatcherRegistry admin set
+stellar contract invoke \
+  --id <WATCHER_REGISTRY_CONTRACT_ID> \
+  --network <NETWORK> \
+  -- \
+  get_admins
+```
+
+* Ensure the compromised address is **not** present in either query result.
+
+---
+
+## 5. Phase 4: State Audit & Remediation
+
+Once administrative control is secured, audit the contracts for malicious modifications:
+
+### 1. WatcherRegistry Audit:
+* **Audit Watcher List:** Call `get_watchers` to inspect all registered watcher nodes.
+* **Revoke Rogue Watchers:** If the attacker registered untrusted addresses, remove them:
+  ```bash
+  stellar contract invoke \
+    --id <WATCHER_REGISTRY_CONTRACT_ID> \
+    --source-account <NEW_ADMIN_SECRET> \
+    --network <NETWORK> \
+    -- \
+    remove_watcher \
+    --admin <NEW_ADMIN_ADDRESS> \
+    --watcher <ROGUE_WATCHER_ADDRESS>
+  ```
+  *(Or execute `clear_all_watchers` and re-register legitimate nodes if extensive tampering occurred).*
+* **Restore Deauthorized Watchers:** Re-register any legitimate watcher nodes that were maliciously removed.
+
+### 2. AlertRegistry Audit:
+* **Check Watcher Gating Address:**
+  ```bash
+  stellar contract invoke \
+    --id <ALERT_REGISTRY_CONTRACT_ID> \
+    --network <NETWORK> \
+    -- \
+    get_watcher_registry
+  ```
+  If pointing to an untrusted contract, restore the correct `WatcherRegistry` address via `set_watcher_registry`.
+* **Check Per-Owner Limit:**
+  ```bash
+  stellar contract invoke \
+    --id <ALERT_REGISTRY_CONTRACT_ID> \
+    --network <NETWORK> \
+    -- \
+    get_per_owner_alert_limit
+  ```
+  Restore the expected limit via `set_per_owner_alert_limit`.
+* **Identify Deleted Alerts:**
+  Query ledger event history for `("alert", "remove")` where caller was the compromised admin. Notify affected alert owners so they can re-register their configurations.
+
+---
+
+## 6. Phase 5: Stakeholder Communication & Disclosure
+
+1. **Downstream Watcher Node Operators:**
+   * Notify watcher node operators via established communication channels (Discord, Telegram, Operator Mailing List).
+   * Advise operators to verify local sync status and check if their node address was temporarily deauthorized.
+2. **Alert Owners:**
+   * If any alerts were deleted during the incident, directly notify affected account owners.
+3. **Public Disclosure:**
+   * Publish a security notice outlining the timeline, affected keys, containment actions taken, and verification steps.
+
+---
+
+## 7. Phase 6: Post-Incident Review & Hardening
+
+1. **Root Cause Analysis (RCA):**
+   * Determine how the private key was accessed (compromised workstation, leaked environment variable, CI/CD vulnerability).
+2. **Key Management Hardening:**
+   * Transition admin keys to hardware security modules (HSMs) or Soroban multisig contracts.
+   * Establish threshold signer sets (e.g. 2-of-3 or 3-of-5 signers) for `WatcherRegistry`.
+3. **Runbook Updates:**
+   * Document lessons learned and update this runbook and `SECURITY.md` accordingly.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -95,3 +95,42 @@ fn test_update_unauthorized() {
 | Happy path | Yes | Business logic works correctly |
 | Unauthorized caller | Yes | Ownership guards reject wrong callers |
 | Auth required | No | `require_auth()` is present and enforced |
+
+## Auth-Required Test Coverage Checklist
+
+Every state-mutating public function in both contracts has been audited and equipped with a dedicated regression test confirming `require_auth()` is strictly enforced.
+
+### AlertRegistry
+
+| Function | Required Signer | Auth Required Test | Status |
+|---|---|---|:---:|
+| `register_alert` | `owner` | `test_register_alert_requires_auth` | ✅ |
+| `update_alert` | `caller` (owner) | `test_update_alert_requires_auth` | ✅ |
+| `update_webhook` | `caller` (owner) | `test_update_webhook_requires_auth` | ✅ |
+| `propose_webhook` | `caller` (owner) | `test_propose_webhook_requires_auth` | ✅ |
+| `confirm_webhook` | `caller` (owner) | `test_confirm_webhook_requires_auth` | ✅ |
+| `renew_alert_ttl` | `caller` (owner) | `test_renew_alert_ttl_requires_auth` | ✅ |
+| `update_label` | `caller` (owner) | `test_update_label_requires_auth` | ✅ |
+| `update_target_contract` | `caller` (owner) | `test_update_target_contract_requires_auth` | ✅ |
+| `deactivate_all_alerts` | `caller` (owner) | `test_deactivate_all_alerts_requires_auth` | ✅ |
+| `remove_alert` | `caller` (owner) | `test_remove_alert_requires_auth` | ✅ |
+| `remove_alert_by_admin` | `admin` | `test_remove_alert_by_admin_requires_auth` | ✅ |
+| `transfer_admin` | `admin` | `test_transfer_admin_requires_auth` | ✅ |
+| `set_per_owner_alert_limit` | `admin` | `test_set_per_owner_alert_limit_requires_auth` | ✅ |
+| `set_watcher_registry` | `admin` | `test_set_watcher_registry_requires_auth` | ✅ |
+| `bump_alert` | *None* (permissionless keeper) | *Tested via `test_bump_alert_by_third_party`* | N/A |
+| `initialize` | *None* (first-caller bootstrap) | *Tested via `test_double_initialize`* | N/A |
+
+### WatcherRegistry
+
+| Function | Required Signer | Auth Required Test | Status |
+|---|---|---|:---:|
+| `initialize` | `admin` | `test_initialize_requires_admin_auth` | ✅ |
+| `add_admin` | `caller` (admin) | `test_add_admin_requires_auth` | ✅ |
+| `remove_admin` | `caller` (admin) | `test_remove_admin_requires_auth` | ✅ |
+| `transfer_admin` | `admin` | `test_transfer_admin_requires_auth` | ✅ |
+| `register_watcher` | `admin` | `test_register_watcher_requires_auth` | ✅ |
+| `remove_watcher` | `admin` | `test_remove_watcher_requires_auth` | ✅ |
+| `replace_watcher` | `admin` | `test_replace_watcher_requires_auth` | ✅ |
+| `clear_all_watchers` | `admin` | `test_clear_all_watchers_requires_auth` | ✅ |
+

--- a/scripts/check-events-doc.sh
+++ b/scripts/check-events-doc.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# scripts/check-events-doc.sh — Check docs/events.md against contract event emissions
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+python3 "${SCRIPT_DIR}/check_events_doc.py" "$@"

--- a/scripts/check_events_doc.py
+++ b/scripts/check_events_doc.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""
+scripts/check_events_doc.py — Verify that docs/events.md accurately reflects
+on-chain event emissions in contract source code.
+
+Checks:
+1. Every event emitted in contract source is documented in docs/events.md under the
+   corresponding contract section.
+2. Every event emitted in contract source is marked as implemented (✅) in docs/events.md.
+3. Every doc entry marked as implemented (✅) actually exists in contract source code.
+4. Planned events (🔲) must not be emitted in source code without being updated to implemented.
+"""
+
+import os
+import re
+import sys
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+DOC_PATH = os.path.join(REPO_ROOT, "docs", "events.md")
+
+CONTRACTS = {
+    "AlertRegistry": os.path.join(REPO_ROOT, "contracts", "alert-registry", "src", "lib.rs"),
+    "WatcherRegistry": os.path.join(REPO_ROOT, "contracts", "watcher-registry", "src", "lib.rs"),
+}
+
+
+def extract_source_events(file_path: str) -> set:
+    """Extract (category, action) pairs published in contract source (excluding tests)."""
+    with open(file_path, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    # Strip test module (from `mod tests {` or `#[cfg(test)]\nmod tests` onwards)
+    test_split = re.split(r"(?:#\[cfg\(test\)\]\s*)?mod\s+tests\s*\{", content)
+    prod_code = test_split[0]
+
+    # Match publish calls:
+    # env.events().publish((symbol_short!("cat"), symbol_short!("act")), ...);
+    # or .publish((symbol_short!("cat"), symbol_short!("act")), ...);
+    pattern = re.compile(
+        r'publish\s*\(\s*\(\s*symbol_short!\(\s*"([^"]+)"\s*\)\s*,\s*symbol_short!\(\s*"([^"]+)"\s*\)\s*\)',
+        re.DOTALL,
+    )
+
+    events = set()
+    for match in pattern.finditer(prod_code):
+        cat, act = match.group(1), match.group(2)
+        events.add(f"{cat}.{act}")
+
+    return events
+
+
+def parse_doc_events(doc_path: str) -> dict:
+    """Parse docs/events.md into contract sections with their events and status."""
+    with open(doc_path, "r", encoding="utf-8") as f:
+        lines = f.readlines()
+
+    doc_data = {"AlertRegistry": {}, "WatcherRegistry": {}}
+    current_contract = None
+    current_event = None
+
+    for line in lines:
+        line_str = line.strip()
+        if line_str.startswith("## "):
+            contract_heading = line_str.replace("## ", "").strip()
+            if "AlertRegistry" in contract_heading:
+                current_contract = "AlertRegistry"
+            elif "WatcherRegistry" in contract_heading:
+                current_contract = "WatcherRegistry"
+            else:
+                current_contract = None
+            current_event = None
+
+        elif line_str.startswith("### ") and current_contract:
+            # e.g., "### `alert.register`" or "### alert.register"
+            event_name = line_str.replace("### ", "").replace("`", "").strip()
+            if "." in event_name:
+                current_event = event_name
+                doc_data[current_contract][current_event] = {"status": "unknown"}
+
+        elif current_contract and current_event and line_str.startswith("**Status:**"):
+            if "✅" in line_str or "implemented" in line_str.lower():
+                doc_data[current_contract][current_event]["status"] = "implemented"
+            elif "🔲" in line_str or "planned" in line_str.lower():
+                doc_data[current_contract][current_event]["status"] = "planned"
+
+    return doc_data
+
+
+def main():
+    print("Checking event emissions in source code against docs/events.md...")
+    doc_data = parse_doc_events(DOC_PATH)
+    has_error = False
+
+    for contract_name, source_file in CONTRACTS.items():
+        print(f"\n--- Checking {contract_name} ({os.path.relpath(source_file, REPO_ROOT)}) ---")
+        if not os.path.exists(source_file):
+            print(f"ERROR: Source file not found: {source_file}")
+            sys.exit(1)
+
+        source_events = extract_source_events(source_file)
+        doc_events = doc_data.get(contract_name, {})
+
+        print(f"Source emitted events: {sorted(list(source_events))}")
+        doc_impl = {k for k, v in doc_events.items() if v["status"] == "implemented"}
+        doc_plan = {k for k, v in doc_events.items() if v["status"] == "planned"}
+        print(f"Doc implemented (✅):   {sorted(list(doc_impl))}")
+        print(f"Doc planned (🔲):       {sorted(list(doc_plan))}")
+
+        # Check 1: Source events missing completely from documentation
+        undocumented = source_events - set(doc_events.keys())
+        if undocumented:
+            print(f"❌ ERROR: Events emitted in {contract_name} source but completely UNDOCUMENTED in docs/events.md:")
+            for e in sorted(undocumented):
+                print(f"   - {e}")
+            has_error = True
+
+        # Check 2: Source events documented as planned instead of implemented
+        false_planned = source_events.intersection(doc_plan)
+        if false_planned:
+            print(f"❌ ERROR: Events emitted in {contract_name} source but marked as planned (🔲) in docs/events.md:")
+            for e in sorted(false_planned):
+                print(f"   - {e}")
+            has_error = True
+
+        # Check 3: Doc entries marked implemented (✅) but not emitted in source
+        phantom_implemented = doc_impl - source_events
+        if phantom_implemented:
+            print(f"❌ ERROR: Events marked implemented (✅) in docs/events.md but NOT emitted in {contract_name} source:")
+            for e in sorted(phantom_implemented):
+                print(f"   - {e}")
+            has_error = True
+
+        if not undocumented and not false_planned and not phantom_implemented:
+            print(f"✅ {contract_name} event documentation is in sync with source code.")
+
+    if has_error:
+        print("\n❌ Event documentation check failed! Please update docs/events.md to match source emissions.")
+        sys.exit(1)
+    else:
+        print("\n✅ All event documentation matches contract source emissions perfectly.")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description

This PR resolves issues #111, #116, #117, and #119:

### 1. #111: Automated Check for Event Documentation Synchronization
- Added `scripts/check_events_doc.py` and wrapper `scripts/check-events-doc.sh` to extract event emissions (`events().publish`) across contract source code and validate against `docs/events.md`.
- Integrated `check-events-doc.sh` into `.github/workflows/ci.yml` and `Makefile` (`make check-events`).
- Updated `docs/events.md` to properly document and mark implemented events (`admin.init`, `admin.add`, `admin.remove`, `watcher.replace`).

### 2. #116: Load Tests Quantifying Scan-Cost Scaling
- Added `test_load_get_alerts_modified_since_instruction_cost` to quantify the O(N) scan cost in `AlertRegistry::get_alerts_modified_since` and establish an instruction budget upper bound.
- Added `test_load_assert_per_owner_limit_instruction_cost` to quantify repeated rescan overhead in `AlertRegistry::assert_per_owner_limit` and assert budget regression bounds.

### 3. #117: Auth-Required Test Coverage Audit
- Audited all state-mutating public entrypoints across `AlertRegistry` and `WatcherRegistry`.
- Added missing `#[should_panic]` auth-required tests without `mock_all_auths()` across both contracts.
- Added a full completion checklist in `docs/testing.md`.

### 4. #119: Incident-Response Runbook for Compromised Admin Key
- Created `docs/incident-response.md` covering threat model/blast radius, detection signals, immediate containment (multi-admin vs single admin), state audit & remediation, stakeholder communication, and post-incident hardening.
- Cross-linked from `SECURITY.md`.

---

## Linked Issues

Closes #111
Closes #116
Closes #117
Closes #119

---

## Verification
- `cargo test --workspace --locked` (185 tests passed)
- `cargo clippy --workspace --all-targets --locked -- -D warnings` (clean)
- `cargo fmt --check` (clean)
- `bash scripts/check-events-doc.sh` (passed)
- `cargo build --release --target wasm32-unknown-unknown --locked -p alert-registry -p watcher-registry` (passed)