### PR TITLE
docs(github): add issue template config pointing to SECURITY.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security Vulnerability Report
+    url: https://github.com/ComputerOracle/contracts/blob/main/SECURITY.md
+    about: Please report security vulnerabilities privately via email (emmanuelanalaba@gmail.com) as detailed in SECURITY.md instead of opening a public issue.


### PR DESCRIPTION
## Description
- Added `.github/ISSUE_TEMPLATE/config.yml` with `blank_issues_enabled: false`.
- Added a contact link directing security vulnerability reports to `SECURITY.md` and the responsible-disclosure contact email rather than opening a public issue.

Closes #108