### PR TITLE
docs: add guide for scaffolding a new contract crate

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,79 @@ bash scripts/deploy.sh
 4. Run `cargo test` to confirm everything passes.
 5. Update the relevant doc in `docs/`.
 
+## Adding a New Contract
+
+When scaffolding an entirely new contract crate in this repository, follow these steps (see `contracts/alert-registry` as a complete worked reference):
+
+### 1. Create Crate Structure & Workspace Registration
+Create a directory under `contracts/<contract-name>` with `src/lib.rs`, `Cargo.toml`, and `build.rs`. Register the new crate in the root `Cargo.toml` under `[workspace] members`:
+
+```toml
+# Cargo.toml
+[workspace]
+members = [
+    "contracts/alert-registry",
+    "contracts/watcher-registry",
+    "contracts/<contract-name>",
+    "contracts/integration-tests",
+    "contracts/test-utils",
+]
+```
+
+### 2. Configure Contract `Cargo.toml`
+Set up `contracts/<contract-name>/Cargo.toml` with the appropriate crate types and workspace dependencies:
+
+```toml
+[package]
+name = "<contract-name>"
+version = "0.1.0"
+edition = "2021"
+rust-version.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+```
+
+### 3. Add `build.rs`
+Copy or create `build.rs` in the contract crate root to ensure compatibility across target OS/environments (e.g., Windows/GNU export-table limit):
+
+```rust
+// contracts/<contract-name>/build.rs
+fn main() {
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows")
+        && std::env::var("CARGO_CFG_TARGET_ENV").as_deref() == Ok("gnu")
+    {
+        println!("cargo:rustc-link-arg=-Wl,--exclude-all-symbols");
+    }
+}
+```
+
+### 4. Scaffold TypeScript Bindings Package
+1. Create `bindings/<contract-name>/` with `package.json`, `tsconfig.json`, and `.npmignore` (refer to `bindings/alert-registry/`).
+2. Generate bindings using the Stellar CLI:
+   ```bash
+   stellar contract bindings typescript \
+     --wasm target/wasm32-unknown-unknown/release/<contract_name>.wasm \
+     --contract-id <CONTRACT_ID> \
+     --output-dir bindings/<contract-name> \
+     --overwrite
+   ```
+
+### 5. Update CI Workflows and Deploy Scripts
+1. **CI Build & Checks:** Add `-p <contract-name>` to the WASM build steps in:
+   - `.github/workflows/ci.yml` (`Build (WASM)` step)
+   - `.github/workflows/wasm-size-check.yml`
+   - `.github/workflows/publish-bindings.yml` (and add bindings generation step)
+   - `.github/workflows/publish-abis.yml`
+2. **Deployment Script:** Update `scripts/deploy.sh` to include the contract in the optimization loop (`stellar contract optimize`) and add deployment/initialization commands for testnet and mainnet.
+3. **Documentation:** Add a dedicated contract reference under `docs/<contract-name>.md`.
+
 ## Sister Repos
  
 - **Core engine:** https://github.com/Tx-wat/stellar-txwatch-core


### PR DESCRIPTION
## Description
- Added an "Adding a New Contract" section to `CONTRIBUTING.md`.
- Covered workspace registration in root `Cargo.toml`, contract `Cargo.toml` configuration, `build.rs` linker configuration, TypeScript bindings scaffolding, and CI/deploy script wiring.
- Cross-referenced `contracts/alert-registry` as a worked example.

Closes #109