### PR TITLE
ci: add dependabot configuration for Cargo, npm, and Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,49 @@
+version: 2
+updates:
+  # Cargo dependencies (workspace root)
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      cargo-dependencies:
+        patterns:
+          - "*"
+
+  # npm dependencies for AlertRegistry TypeScript bindings
+  - package-ecosystem: "npm"
+    directory: "/bindings/alert-registry"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"
+
+  # npm dependencies for WatcherRegistry TypeScript bindings
+  - package-ecosystem: "npm"
+    directory: "/bindings/watcher-registry"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"
+
+  # GitHub Actions workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Description
- Added `.github/dependabot.yml` configured for:
  - Cargo ecosystem for the workspace root (`/`)
  - npm ecosystem for `@tx-wat/alert-registry-bindings` (`/bindings/alert-registry`)
  - npm ecosystem for `@tx-wat/watcher-registry` (`/bindings/watcher-registry`)
  - GitHub Actions ecosystem (`/`)
- Set up weekly update checks with grouping rules to minimize PR noise and prevent dependency drift.

## Related Issue
Closes #101

## Type of change
- Chore
- CI / Infrastructure

## Checklist
- [x] My code follows the repository style
- [x] I have updated or added documentation if necessary
- [x] All CI checks pass