### PR TITLE
docs: document release and tagging process in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,52 @@ bash scripts/deploy.sh
 4. Run `cargo test` to confirm everything passes.
 5. Update the relevant doc in `docs/`.
 
+## Cutting a Release
+
+Releases follow a specific two-phase trigger sequence due to how GitHub Actions workflows are structured:
+
+1. **Git Tag (`vX.Y.Z`)** triggers `.github/workflows/deploy-testnet.yml`, which compiles the contracts, deploys them to Stellar testnet, updates `DEPLOYMENTS.md`, and opens a pull request with the new addresses.
+2. **GitHub Release (`published`)** triggers `.github/workflows/publish-abis.yml` and `.github/workflows/publish-bindings.yml`, which generate the JSON ABIs, upload them to the release assets, and generate/publish the TypeScript npm bindings.
+
+Because these triggers are decoupled, releases must follow the sequence below in exact order.
+
+### Release Sequence
+
+1. **Prepare Release**
+   - Ensure all target PRs are merged to `main`.
+   - Update `CHANGELOG.md` by moving items from `[Unreleased]` to a new version header `[X.Y.Z] - YYYY-MM-DD`.
+   - Commit and push changes to `main`.
+
+2. **Create and Push Git Tag**
+   ```bash
+   git checkout main
+   git pull origin main
+   git tag -a vX.Y.Z -m "Release vX.Y.Z"
+   git push origin vX.Y.Z
+   ```
+
+3. **Verify Testnet Deployment & Merge Addresses**
+   - Monitor the **Deploy to Testnet** workflow on GitHub Actions.
+   - Once completed, review and merge the automated PR (`deploy/update-deployments-vX.Y.Z`) into `main`.
+
+4. **Publish GitHub Release**
+   - In GitHub, navigate to **Releases** → **Draft a new release**.
+   - Select the existing tag `vX.Y.Z`.
+   - Set the title to `vX.Y.Z` and paste the release notes from `CHANGELOG.md`.
+   - Click **Publish release**.
+
+5. **Verify Automated Publishing**
+   - Monitor the **Publish Contract ABIs** and **Publish TypeScript Bindings** workflows triggered by the published release.
+
+### Release Verification Checklist
+
+- [ ] `vX.Y.Z` tag created and pushed to remote repository.
+- [ ] `Deploy to Testnet` workflow completed successfully.
+- [ ] Automated `deploy/update-deployments-vX.Y.Z` PR reviewed and merged to `main`.
+- [ ] GitHub Release `vX.Y.Z` created and published using the tag.
+- [ ] `Publish Contract ABIs` workflow passed and attached ABI JSON files (`alert-registry.json`, `watcher-registry.json`) to the release.
+- [ ] `Publish TypeScript Bindings` workflow passed and published the latest package to npm.
+
 ## Sister Repos
  
 - **Core engine:** https://github.com/Tx-wat/stellar-txwatch-core


### PR DESCRIPTION
## Description
- Added a "Cutting a Release" section to `CONTRIBUTING.md`.
- Documented the exact two-phase sequence:
  1. Pushing `vX.Y.Z` git tag to trigger testnet deployment and update `DEPLOYMENTS.md`.
  2. Publishing GitHub Release to trigger ABI JSON generation and TypeScript bindings publishing to npm.
- Added a release verification checklist to verify every workflow stage completed successfully.

## Related Issue
Closes #99

## Type of change
- Docs update

## Checklist
- [x] My code follows the repository style
- [x] I have updated or added documentation if necessary
- [x] All CI checks pass