### PR TITLE
test: cover pre-initialize NotInitialized error across WatcherRegistry entrypoints (#71)

### DIFF
--- a/contracts/watcher-registry/src/lib.rs
+++ b/contracts/watcher-registry/src/lib.rs
@@ -1215,4 +1215,130 @@ mod tests {
         env.set_auths(&[]);
         client.clear_all_watchers(&admin);
     }
+
+    // === Pre-initialization coverage
+    // Every admin-gated entrypoint routes through assert_admin, which returns
+    // NotInitialized before initialize() has run; get_admins runs the same check
+    // directly. test_get_admin_uninitialized already covers get_admin, so these
+    // close the gap for the rest of that surface.
+
+    fn uninit() -> (Env, WatcherRegistryClient<'static>) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(WatcherRegistry, ());
+        let client = WatcherRegistryClient::new(&env, &contract_id);
+        (env, client)
+    }
+
+    #[test]
+    fn test_clear_all_watchers_before_initialize() {
+        let (env, client) = uninit();
+        let admin = Address::generate(&env);
+
+        assert_eq!(
+            client.try_clear_all_watchers(&admin).unwrap_err().unwrap(),
+            ContractError::NotInitialized
+        );
+    }
+
+    #[test]
+    fn test_add_admin_before_initialize() {
+        let (env, client) = uninit();
+        let caller = Address::generate(&env);
+        let new_admin = Address::generate(&env);
+
+        assert_eq!(
+            client
+                .try_add_admin(&caller, &new_admin)
+                .unwrap_err()
+                .unwrap(),
+            ContractError::NotInitialized
+        );
+    }
+
+    #[test]
+    fn test_remove_admin_before_initialize() {
+        let (env, client) = uninit();
+        let caller = Address::generate(&env);
+        let target = Address::generate(&env);
+
+        assert_eq!(
+            client
+                .try_remove_admin(&caller, &target)
+                .unwrap_err()
+                .unwrap(),
+            ContractError::NotInitialized
+        );
+    }
+
+    #[test]
+    fn test_transfer_admin_before_initialize() {
+        let (env, client) = uninit();
+        let admin = Address::generate(&env);
+        let new_admin = Address::generate(&env);
+
+        assert_eq!(
+            client
+                .try_transfer_admin(&admin, &new_admin)
+                .unwrap_err()
+                .unwrap(),
+            ContractError::NotInitialized
+        );
+    }
+
+    #[test]
+    fn test_register_watcher_before_initialize() {
+        let (env, client) = uninit();
+        let admin = Address::generate(&env);
+        let watcher = Address::generate(&env);
+
+        assert_eq!(
+            client
+                .try_register_watcher(&admin, &watcher)
+                .unwrap_err()
+                .unwrap(),
+            ContractError::NotInitialized
+        );
+    }
+
+    #[test]
+    fn test_remove_watcher_before_initialize() {
+        let (env, client) = uninit();
+        let admin = Address::generate(&env);
+        let watcher = Address::generate(&env);
+
+        assert_eq!(
+            client
+                .try_remove_watcher(&admin, &watcher)
+                .unwrap_err()
+                .unwrap(),
+            ContractError::NotInitialized
+        );
+    }
+
+    #[test]
+    fn test_replace_watcher_before_initialize() {
+        let (env, client) = uninit();
+        let admin = Address::generate(&env);
+        let old_watcher = Address::generate(&env);
+        let new_watcher = Address::generate(&env);
+
+        assert_eq!(
+            client
+                .try_replace_watcher(&admin, &old_watcher, &new_watcher)
+                .unwrap_err()
+                .unwrap(),
+            ContractError::NotInitialized
+        );
+    }
+
+    #[test]
+    fn test_get_admins_before_initialize() {
+        let (_env, client) = uninit();
+
+        assert_eq!(
+            client.try_get_admins().unwrap_err().unwrap(),
+            ContractError::NotInitialized
+        );
+    }
 }


### PR DESCRIPTION
Closes #71.

## What

`clear_all_watchers`'s pre-initialization behavior (`NotInitialized` via `assert_admin`) was implied but never exercised, unlike `get_admin` which has `test_get_admin_uninitialized`. This adds `test_clear_all_watchers_before_initialize` plus the same assertion for every other entrypoint with the same gap.

### Tests added (new `// === Pre-initialization coverage` section)

- `test_clear_all_watchers_before_initialize`
- `test_add_admin_before_initialize`
- `test_remove_admin_before_initialize`
- `test_transfer_admin_before_initialize`
- `test_register_watcher_before_initialize`
- `test_remove_watcher_before_initialize`
- `test_replace_watcher_before_initialize`
- `test_get_admins_before_initialize`

Each asserts `ContractError::NotInitialized` via the `try_` client, mirroring `test_get_admin_uninitialized`.

## Audit

Every admin-gated entrypoint routes through `assert_admin` (lib.rs:494-497), which returns `NotInitialized` before `initialize`; `get_admins` runs the same check directly (lib.rs:421). Only `get_admin` had dedicated coverage before this change. The 8 tests close the gap for the rest of that surface. No production code changed.

## Verification

- `cargo test -p watcher-registry --locked` -> 53 passed, 0 failed
- `cargo fmt --all -- --check` clean
- `cargo clippy -p watcher-registry --all-targets --locked -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)