### PR TITLE
Fix/watcher registry admin governance hardening

### DIFF
--- a/contracts/alert-registry/src/lib.rs
+++ b/contracts/alert-registry/src/lib.rs
@@ -72,6 +72,8 @@ pub enum ContractError {
     DuplicateAlertId = 11,
     /// Returned by `confirm_webhook` when no webhook rotation is in progress.
     NoPendingWebhook = 12,
+    /// Returned when a state-mutating call is made while the contract is paused.
+    Paused = 13,
 }
 
 // ── Data types ───────────────────────────────────────────────────────────────
@@ -178,6 +180,7 @@ impl AlertRegistry {
     ) -> Result<(), ContractError> {
         admin.require_auth();
         Self::assert_admin(&env, &admin)?;
+        Self::assert_not_paused(&env)?;
         env.storage()
             .instance()
             .set(&symbol_short!("ADMIN"), &new_admin);
@@ -201,6 +204,52 @@ impl AlertRegistry {
             .unwrap_or_else(|| panic_with_error!(&env, ContractError::NotInitialized))
     }
 
+    /// Pause the contract, rejecting all state-mutating calls until [`Self::unpause`] is called.
+    ///
+    /// Intended as an emergency circuit-breaker if an admin key is suspected
+    /// compromised — mutations can be frozen while the incident is investigated.
+    /// # Auth
+    /// Requires a valid Stellar auth signature from `admin`.
+    /// # Errors
+    /// Returns [`ContractError::NotInitialized`] if the contract has not been initialized.
+    /// Returns [`ContractError::Unauthorized`] if the caller is not authorized for this operation.
+    pub fn pause(env: Env, admin: Address) -> Result<(), ContractError> {
+        admin.require_auth();
+        Self::assert_admin(&env, &admin)?;
+        env.storage()
+            .instance()
+            .set(&symbol_short!("PAUSED"), &true);
+        env.events()
+            .publish((symbol_short!("admin"), symbol_short!("pause")), admin);
+        Ok(())
+    }
+
+    /// Resume normal operation after a [`Self::pause`].
+    /// # Auth
+    /// Requires a valid Stellar auth signature from `admin`.
+    /// # Errors
+    /// Returns [`ContractError::NotInitialized`] if the contract has not been initialized.
+    /// Returns [`ContractError::Unauthorized`] if the caller is not authorized for this operation.
+    pub fn unpause(env: Env, admin: Address) -> Result<(), ContractError> {
+        admin.require_auth();
+        Self::assert_admin(&env, &admin)?;
+        env.storage()
+            .instance()
+            .set(&symbol_short!("PAUSED"), &false);
+        env.events()
+            .publish((symbol_short!("admin"), symbol_short!("unpause")), admin);
+        Ok(())
+    }
+
+    /// Return `true` if the contract is currently paused.
+    #[must_use]
+    pub fn is_paused(env: Env) -> bool {
+        env.storage()
+            .instance()
+            .get(&symbol_short!("PAUSED"))
+            .unwrap_or(false)
+    }
+
     /// Set a per-owner active alert limit (admin only). A value of `0` means no limit.
     /// # Errors
     /// Returns [`ContractError::NotInitialized`] if the contract has not been initialized.
@@ -212,6 +261,7 @@ impl AlertRegistry {
     ) -> Result<(), ContractError> {
         admin.require_auth();
         Self::assert_admin(&env, &admin)?;
+        Self::assert_not_paused(&env)?;
         env.storage()
             .instance()
             .set(&symbol_short!("LIMIT"), &limit);
@@ -245,6 +295,7 @@ impl AlertRegistry {
     ) -> Result<(), ContractError> {
         admin.require_auth();
         Self::assert_admin(&env, &admin)?;
+        Self::assert_not_paused(&env)?;
         env.storage()
             .instance()
             .set(&symbol_short!("WATCHREG"), &watcher_registry);
@@ -303,6 +354,7 @@ impl AlertRegistry {
             return Err(ContractError::InvalidWebhookHash);
         }
         owner.require_auth();
+        Self::assert_not_paused(&env)?;
 
         if label.len() > 128 {
             return Err(ContractError::LabelTooLong);
@@ -365,6 +417,7 @@ impl AlertRegistry {
         active: bool,
     ) -> Result<(), ContractError> {
         caller.require_auth();
+        Self::assert_not_paused(&env)?;
 
         let mut config: AlertConfig = env
             .storage()
@@ -423,6 +476,7 @@ impl AlertRegistry {
         webhook_hash: String,
     ) -> Result<(), ContractError> {
         caller.require_auth();
+        Self::assert_not_paused(&env)?;
 
         if webhook_hash.len() != 64 {
             return Err(ContractError::InvalidWebhookHash);
@@ -484,6 +538,7 @@ impl AlertRegistry {
         webhook_hash: String,
     ) -> Result<(), ContractError> {
         caller.require_auth();
+        Self::assert_not_paused(&env)?;
 
         if webhook_hash.len() != 64 {
             return Err(ContractError::InvalidWebhookHash);
@@ -530,6 +585,7 @@ impl AlertRegistry {
     /// Emits `(Symbol("alert"), Symbol("wh_conf"))` with data `(id: u64, caller: Address)`.
     pub fn confirm_webhook(env: Env, caller: Address, config_id: u64) -> Result<(), ContractError> {
         caller.require_auth();
+        Self::assert_not_paused(&env)?;
 
         let mut config: AlertConfig = env
             .storage()
@@ -577,6 +633,7 @@ impl AlertRegistry {
     /// Returns [`ContractError::Unauthorized`] if `caller` is not the owner.
     pub fn renew_alert_ttl(env: Env, caller: Address, config_id: u64) -> Result<(), ContractError> {
         caller.require_auth();
+        Self::assert_not_paused(&env)?;
 
         let config: AlertConfig = env
             .storage()
@@ -629,6 +686,7 @@ impl AlertRegistry {
         label: String,
     ) -> Result<(), ContractError> {
         caller.require_auth();
+        Self::assert_not_paused(&env)?;
 
         if label.len() > 128 {
             return Err(ContractError::LabelTooLong);
@@ -676,6 +734,7 @@ impl AlertRegistry {
     /// Returns [`ContractError::Unauthorized`] if the caller is not authorized for this operation.
     pub fn remove_alert(env: Env, caller: Address, config_id: u64) -> Result<(), ContractError> {
         caller.require_auth();
+        Self::assert_not_paused(&env)?;
 
         let config: AlertConfig = env
             .storage()
@@ -703,6 +762,7 @@ impl AlertRegistry {
     ) -> Result<(), ContractError> {
         admin.require_auth();
         Self::assert_admin(&env, &admin)?;
+        Self::assert_not_paused(&env)?;
 
         let config: AlertConfig = env
             .storage()
@@ -736,6 +796,8 @@ impl AlertRegistry {
     /// Emits `(Symbol("alert"), Symbol("bump"))` with data
     /// `(id: u64, ttl: u32)` so off-chain indexers can track renewal activity.
     pub fn bump_alert(env: Env, config_id: u64, ttl: u32) -> Result<(), ContractError> {
+        Self::assert_not_paused(&env)?;
+
         // Clamp the requested TTL to the protocol maximum.
         let effective_ttl = ttl.min(MAX_TTL);
 
@@ -890,6 +952,9 @@ impl AlertRegistry {
     /// Panics if the contract's stored state is malformed or missing.
     pub fn deactivate_all_alerts(env: Env, caller: Address) -> u32 {
         caller.require_auth();
+        if Self::is_paused(env.clone()) {
+            return 0;
+        }
         let ids = Self::owner_index(&env, &caller);
         let mut count: u32 = 0;
         for i in 0..ids.len() {
@@ -942,6 +1007,7 @@ impl AlertRegistry {
         new_target: Address,
     ) -> Result<(), ContractError> {
         caller.require_auth();
+        Self::assert_not_paused(&env)?;
 
         let mut config: AlertConfig = env
             .storage()
@@ -1070,6 +1136,18 @@ impl AlertRegistry {
         } else {
             Err(ContractError::Unauthorized)
         }
+    }
+
+    fn assert_not_paused(env: &Env) -> Result<(), ContractError> {
+        let paused: bool = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("PAUSED"))
+            .unwrap_or(false);
+        if paused {
+            return Err(ContractError::Paused);
+        }
+        Ok(())
     }
 
     fn assert_admin(env: &Env, caller: &Address) -> Result<(), ContractError> {

--- a/contracts/alert-registry/src/tests.rs
+++ b/contracts/alert-registry/src/tests.rs
@@ -235,6 +235,84 @@ fn test_admin_transfer_admin() {
     client.remove_alert_by_admin(&new_admin, &id);
 }
 
+// ── Pause / circuit-breaker tests ────────────────────────────────────────
+
+#[test]
+fn test_pause_blocks_mutations() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    let target = Address::generate(&env);
+
+    client.pause(&admin);
+    assert!(client.is_paused());
+
+    let result = client.try_register_alert(
+        &owner,
+        &target,
+        &str(&env, "Alert"),
+        &hash64(&env),
+        &vec![&env, str(&env, "rule:transfer")],
+    );
+    assert_eq!(result.unwrap_err().unwrap(), ContractError::Paused);
+}
+
+#[test]
+fn test_unpause_restores_mutations() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    let target = Address::generate(&env);
+
+    client.pause(&admin);
+    client.unpause(&admin);
+    assert!(!client.is_paused());
+
+    let id = client.register_alert(
+        &owner,
+        &target,
+        &str(&env, "Alert"),
+        &hash64(&env),
+        &vec![&env, str(&env, "rule:transfer")],
+    );
+    assert!(client.get_alert(&id).is_some());
+}
+
+#[test]
+fn test_pause_allows_reads() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    let target = Address::generate(&env);
+
+    let id = client.register_alert(
+        &owner,
+        &target,
+        &str(&env, "Alert"),
+        &hash64(&env),
+        &vec![&env, str(&env, "rule:transfer")],
+    );
+
+    client.pause(&admin);
+
+    assert!(client.get_alert(&id).is_some());
+    assert_eq!(client.get_alert_count(), 1);
+}
+
+#[test]
+fn test_pause_unauthorized() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+    let attacker = Address::generate(&env);
+
+    let result = client.try_pause(&attacker);
+    assert_eq!(result.unwrap_err().unwrap(), ContractError::Unauthorized);
+}
+
 // 5. Unauthorized remove rejected
 #[test]
 fn test_remove_unauthorized() {

--- a/contracts/watcher-registry/src/lib.rs
+++ b/contracts/watcher-registry/src/lib.rs
@@ -155,11 +155,19 @@ impl WatcherRegistry {
         Ok(())
     }
 
-    /// Transfer the sole admin role to a new address (any existing admin may call this).
+    /// Transfer the caller's own admin slot to a new address (any existing
+    /// admin may call this, and only affects that admin's own membership).
     ///
-    /// This replaces the **entire** admin set with a single new admin. Use
-    /// [`add_admin`] + [`remove_admin`] if you want to rotate one member of a
-    /// multi-admin set without losing the others.
+    /// This replaces **only the caller's own entry** in the admin set with
+    /// `new_admin` — every other admin's membership is left untouched. In a
+    /// multi-admin set this means no single admin can unilaterally strip the
+    /// others; each admin can only hand off their own slot. Use [`add_admin`]
+    /// + [`remove_admin`] if you need finer-grained control over another
+    /// admin's membership (which itself requires that admin's own consent to
+    /// remove, aside from the last-admin guard).
+    ///
+    /// If `new_admin` is already an admin, the caller's slot is simply
+    /// dropped rather than duplicated.
     ///
     /// Emits an `("admin", "transfer")` event recording both the old and new admin.
     ///
@@ -177,10 +185,25 @@ impl WatcherRegistry {
         admin.require_auth();
         Self::assert_admin(&env, &admin)?;
 
-        let new_admins: Vec<Address> = vec![&env, new_admin.clone()];
-        env.storage().instance().set(&DataKey::Admins, &new_admins);
+        let admins = Self::load_admins(&env);
+        let mut updated: Vec<Address> = vec![&env];
+        let mut new_already_present = false;
+        for i in 0..admins.len() {
+            let a = admins.get(i).unwrap();
+            if a == admin {
+                continue;
+            }
+            if a == new_admin {
+                new_already_present = true;
+            }
+            updated.push_back(a);
+        }
+        if !new_already_present {
+            updated.push_back(new_admin.clone());
+        }
+        env.storage().instance().set(&DataKey::Admins, &updated);
 
-        // Emit an auditable on-chain event recording the full admin transfer.
+        // Emit an auditable on-chain event recording the admin slot transfer.
         env.events().publish(
             (symbol_short!("admin"), symbol_short!("transfer")),
             (admin, new_admin),
@@ -512,6 +535,15 @@ mod tests {
     use super::*;
     use soroban_sdk::{testutils::Address as _, testutils::Events as _, Env};
 
+    fn vec_contains(items: &Vec<Address>, target: &Address) -> bool {
+        for i in 0..items.len() {
+            if items.get(i).unwrap() == *target {
+                return true;
+            }
+        }
+        false
+    }
+
     fn setup() -> (Env, Address, WatcherRegistryClient<'static>) {
         let env = Env::default();
         env.mock_all_auths();
@@ -817,6 +849,67 @@ mod tests {
     }
 
     // ── Multi-admin tests ─────────────────────────────────────────────────────
+
+    // transfer_admin only replaces the caller's own slot, preserving co-admins.
+    #[test]
+    fn test_transfer_admin_preserves_co_admins() {
+        let (env, admin, client) = setup();
+        let second_admin = Address::generate(&env);
+        let new_admin = Address::generate(&env);
+
+        assert_eq!(client.try_add_admin(&admin, &second_admin).unwrap(), Ok(()));
+        assert_eq!(client.get_admins().len(), 2);
+
+        // admin transfers its own slot to new_admin.
+        assert_eq!(
+            client.try_transfer_admin(&admin, &new_admin).unwrap(),
+            Ok(())
+        );
+
+        let admins = client.get_admins();
+        assert_eq!(admins.len(), 2);
+        assert!(vec_contains(&admins, &new_admin));
+        assert!(vec_contains(&admins, &second_admin));
+        assert!(!vec_contains(&admins, &admin));
+
+        // the old admin slot no longer has privileges...
+        assert_eq!(
+            client
+                .try_add_admin(&admin, &Address::generate(&env))
+                .unwrap_err()
+                .unwrap(),
+            ContractError::Unauthorized
+        );
+        // ...but the co-admin that was never touched still does.
+        assert_eq!(
+            client
+                .try_add_admin(&second_admin, &Address::generate(&env))
+                .unwrap(),
+            Ok(())
+        );
+    }
+
+    // transfer_admin cannot be used by one admin to strip every other admin.
+    #[test]
+    fn test_transfer_admin_cannot_strip_other_admins() {
+        let (env, admin, client) = setup();
+        let second_admin = Address::generate(&env);
+        let attacker_target = Address::generate(&env);
+
+        assert_eq!(client.try_add_admin(&admin, &second_admin).unwrap(), Ok(()));
+
+        // admin transfers its own slot to a brand new address — at no point
+        // does second_admin lose its slot, since transfer_admin only ever
+        // touches the caller's own entry.
+        assert_eq!(
+            client.try_transfer_admin(&admin, &attacker_target).unwrap(),
+            Ok(())
+        );
+
+        let admins = client.get_admins();
+        assert_eq!(admins.len(), 2);
+        assert!(vec_contains(&admins, &second_admin));
+    }
 
     // 13. add_admin — second admin can perform privileged operations
     #[test]

--- a/contracts/watcher-registry/src/lib.rs
+++ b/contracts/watcher-registry/src/lib.rs
@@ -27,8 +27,10 @@ pub enum ContractError {
     LastAdmin = 4,
     /// Returned when the specified watcher is not currently registered.
     WatcherNotFound = 5,
+    /// Returned when a state-mutating call is made while the contract is paused.
+    Paused = 6,
     /// Returned when an operation would drop the watcher count below [`MIN_WATCHERS`].
-    BelowMinWatchers = 6,
+    BelowMinWatchers = 7,
 }
 
 /// Minimum number of registered watchers that must remain after
@@ -45,6 +47,8 @@ pub enum DataKey {
     Admins,
     /// Stores the `Vec<Address>` of authorized watcher nodes.
     Watchers,
+    /// Stores the `bool` paused flag.
+    Paused,
 }
 
 // ── Contract ─────────────────────────────────────────────────────────────────
@@ -100,6 +104,7 @@ impl WatcherRegistry {
     pub fn add_admin(env: Env, caller: Address, new_admin: Address) -> Result<(), ContractError> {
         caller.require_auth();
         Self::assert_admin(&env, &caller)?;
+        Self::assert_not_paused(&env)?;
 
         let mut admins = Self::load_admins(&env);
         for i in 0..admins.len() {
@@ -139,6 +144,7 @@ impl WatcherRegistry {
     ) -> Result<(), ContractError> {
         caller.require_auth();
         Self::assert_admin(&env, &caller)?;
+        Self::assert_not_paused(&env)?;
 
         let admins = Self::load_admins(&env);
         if admins.len() <= 1 {
@@ -191,6 +197,7 @@ impl WatcherRegistry {
     ) -> Result<(), ContractError> {
         admin.require_auth();
         Self::assert_admin(&env, &admin)?;
+        Self::assert_not_paused(&env)?;
 
         let admins = Self::load_admins(&env);
         let mut updated: Vec<Address> = vec![&env];
@@ -234,6 +241,7 @@ impl WatcherRegistry {
     ) -> Result<(), ContractError> {
         admin.require_auth();
         Self::assert_admin(&env, &admin)?;
+        Self::assert_not_paused(&env)?;
 
         let mut watchers = Self::load_watchers(&env);
         for i in 0..watchers.len() {
@@ -278,6 +286,7 @@ impl WatcherRegistry {
     pub fn remove_watcher(env: Env, admin: Address, watcher: Address) -> Result<(), ContractError> {
         admin.require_auth();
         Self::assert_admin(&env, &admin)?;
+        Self::assert_not_paused(&env)?;
 
         let watchers = Self::load_watchers(&env);
         let mut updated: Vec<Address> = vec![&env];
@@ -340,6 +349,7 @@ impl WatcherRegistry {
     ) -> Result<(), ContractError> {
         admin.require_auth();
         Self::assert_admin(&env, &admin)?;
+        Self::assert_not_paused(&env)?;
 
         let watchers = Self::load_watchers(&env);
         let mut found = false;
@@ -430,6 +440,7 @@ impl WatcherRegistry {
     pub fn clear_all_watchers(env: Env, admin: Address) -> Result<(), ContractError> {
         admin.require_auth();
         Self::assert_admin(&env, &admin)?;
+        Self::assert_not_paused(&env)?;
 
         let watchers = Self::load_watchers(&env);
         if !watchers.is_empty() && MIN_WATCHERS > 0 {
@@ -483,6 +494,50 @@ impl WatcherRegistry {
         Ok(admins.get(0).unwrap())
     }
 
+    /// Pause the contract, rejecting all state-mutating calls until [`Self::unpause`] is called.
+    ///
+    /// Intended as an emergency circuit-breaker if an admin key is suspected
+    /// compromised — mutations can be frozen while the incident is investigated.
+    /// # Auth
+    /// Requires a valid Stellar auth signature from `caller`, who must be an
+    /// existing admin.
+    /// # Errors
+    /// Returns [`ContractError::NotInitialized`] if the contract has not been initialized.
+    /// Returns [`ContractError::Unauthorized`] if the caller is not authorized for this operation.
+    pub fn pause(env: Env, caller: Address) -> Result<(), ContractError> {
+        caller.require_auth();
+        Self::assert_admin(&env, &caller)?;
+        env.storage().instance().set(&DataKey::Paused, &true);
+        env.events()
+            .publish((symbol_short!("admin"), symbol_short!("pause")), caller);
+        Ok(())
+    }
+
+    /// Resume normal operation after a [`Self::pause`].
+    /// # Auth
+    /// Requires a valid Stellar auth signature from `caller`, who must be an
+    /// existing admin.
+    /// # Errors
+    /// Returns [`ContractError::NotInitialized`] if the contract has not been initialized.
+    /// Returns [`ContractError::Unauthorized`] if the caller is not authorized for this operation.
+    pub fn unpause(env: Env, caller: Address) -> Result<(), ContractError> {
+        caller.require_auth();
+        Self::assert_admin(&env, &caller)?;
+        env.storage().instance().set(&DataKey::Paused, &false);
+        env.events()
+            .publish((symbol_short!("admin"), symbol_short!("unpause")), caller);
+        Ok(())
+    }
+
+    /// Return `true` if the contract is currently paused.
+    #[must_use]
+    pub fn is_paused(env: Env) -> bool {
+        env.storage()
+            .instance()
+            .get(&DataKey::Paused)
+            .unwrap_or(false)
+    }
+
     /// Get the number of registered watchers as a cheap u32 read, avoiding
     /// the cost of fetching and deserializing the full watcher list.
     #[must_use]
@@ -533,6 +588,15 @@ impl WatcherRegistry {
             .instance()
             .get(&DataKey::Admins)
             .unwrap_or_else(|| vec![env])
+    }
+
+    /// Return `Ok(())` if the contract is not paused, `Err(Paused)` otherwise.
+    fn assert_not_paused(env: &Env) -> Result<(), ContractError> {
+        let paused: bool = env.storage().instance().get(&DataKey::Paused).unwrap_or(false);
+        if paused {
+            return Err(ContractError::Paused);
+        }
+        Ok(())
     }
 
     /// Return `Ok(())` if `caller` is in the admin set, `Err(Unauthorized)` otherwise.
@@ -992,6 +1056,60 @@ mod tests {
         assert_eq!(
             client.try_clear_all_watchers(&admin).unwrap_err().unwrap(),
             ContractError::BelowMinWatchers
+        );
+    }
+
+    // ── Pause / circuit-breaker tests ────────────────────────────────────────
+
+    // pause blocks state-mutating calls, unpause restores them
+    #[test]
+    fn test_pause_blocks_mutations() {
+        let (env, admin, client) = setup();
+        let watcher = Address::generate(&env);
+
+        assert_eq!(client.try_pause(&admin).unwrap(), Ok(()));
+        assert!(client.is_paused());
+
+        assert_eq!(
+            client
+                .try_register_watcher(&admin, &watcher)
+                .unwrap_err()
+                .unwrap(),
+            ContractError::Paused
+        );
+
+        assert_eq!(client.try_unpause(&admin).unwrap(), Ok(()));
+        assert!(!client.is_paused());
+
+        assert_eq!(
+            client.try_register_watcher(&admin, &watcher).unwrap(),
+            Ok(())
+        );
+    }
+
+    // pause does not block read-only calls
+    #[test]
+    fn test_pause_allows_reads() {
+        let (env, admin, client) = setup();
+        let watcher = Address::generate(&env);
+        client.register_watcher(&admin, &watcher);
+
+        client.pause(&admin);
+
+        assert!(client.is_watcher_authorized(&watcher));
+        assert_eq!(client.get_watchers().len(), 1);
+        assert_eq!(client.get_admins().len(), 1);
+    }
+
+    // only an admin can pause/unpause
+    #[test]
+    fn test_pause_unauthorized() {
+        let (env, _admin, client) = setup();
+        let attacker = Address::generate(&env);
+
+        assert_eq!(
+            client.try_pause(&attacker).unwrap_err().unwrap(),
+            ContractError::Unauthorized
         );
     }
 

--- a/contracts/watcher-registry/src/lib.rs
+++ b/contracts/watcher-registry/src/lib.rs
@@ -27,7 +27,14 @@ pub enum ContractError {
     LastAdmin = 4,
     /// Returned when the specified watcher is not currently registered.
     WatcherNotFound = 5,
+    /// Returned when an operation would drop the watcher count below [`MIN_WATCHERS`].
+    BelowMinWatchers = 6,
 }
+
+/// Minimum number of registered watchers that must remain after
+/// `remove_watcher` or `clear_all_watchers`. Prevents an admin (or a
+/// compromised admin key) from halting the monitoring system entirely.
+pub const MIN_WATCHERS: u32 = 1;
 
 // ── Storage keys ─────────────────────────────────────────────────────────────
 
@@ -250,7 +257,8 @@ impl WatcherRegistry {
     /// Remove (deauthorize) a watcher (any admin may call this).
     ///
     /// If the watcher address is not currently registered this is a no-op —
-    /// the call succeeds and no event is emitted.
+    /// the call succeeds and no event is emitted. Refuses to drop the
+    /// watcher count below [`MIN_WATCHERS`].
     ///
     /// # Auth
     /// Requires a valid Stellar auth signature from `admin`, who must be an
@@ -262,6 +270,7 @@ impl WatcherRegistry {
     /// Dependent systems (e.g. `AlertRegistry` watcher-gating) should listen
     /// for this event to revoke trust immediately.
     /// # Errors
+    /// Returns [`ContractError::BelowMinWatchers`] if removing this watcher would drop the count below [`MIN_WATCHERS`].
     /// Returns [`ContractError::NotInitialized`] if the contract has not been initialized.
     /// Returns [`ContractError::Unauthorized`] if the caller is not authorized for this operation.
     /// # Panics
@@ -281,6 +290,11 @@ impl WatcherRegistry {
                 updated.push_back(w);
             }
         }
+
+        if removed && updated.len() < MIN_WATCHERS {
+            return Err(ContractError::BelowMinWatchers);
+        }
+
         env.storage().instance().set(&DataKey::Watchers, &updated);
 
         // Only emit the event and decrement the counter when the watcher was
@@ -399,12 +413,16 @@ impl WatcherRegistry {
     ///
     /// This is a bulk deauthorization operation.  Each removed watcher emits
     /// a `("watcher", "remove")` event so dependent systems can revoke trust
-    /// for every affected address.
+    /// for every affected address. Refused outright when [`MIN_WATCHERS`] is
+    /// greater than zero and the registry is non-empty, since clearing would
+    /// necessarily drop the count below that threshold; use [`remove_watcher`]
+    /// for selective removal instead.
     ///
     /// # Auth
     /// Requires a valid Stellar auth signature from `admin`, who must be an
     /// existing admin.
     /// # Errors
+    /// Returns [`ContractError::BelowMinWatchers`] if the registry is non-empty and [`MIN_WATCHERS`] is greater than zero.
     /// Returns [`ContractError::NotInitialized`] if the contract has not been initialized.
     /// Returns [`ContractError::Unauthorized`] if the caller is not authorized for this operation.
     /// # Panics
@@ -414,6 +432,10 @@ impl WatcherRegistry {
         Self::assert_admin(&env, &admin)?;
 
         let watchers = Self::load_watchers(&env);
+        if !watchers.is_empty() && MIN_WATCHERS > 0 {
+            return Err(ContractError::BelowMinWatchers);
+        }
+
         for i in 0..watchers.len() {
             let w = watchers.get(i).unwrap();
             env.events()
@@ -739,10 +761,20 @@ mod tests {
         assert_eq!(client.try_register_watcher(&admin, &w3).unwrap(), Ok(()));
         assert_eq!(client.get_watchers().len(), 3);
 
+        // Down to MIN_WATCHERS (1) removals succeed...
         assert_eq!(client.try_remove_watcher(&admin, &w1).unwrap(), Ok(()));
         assert_eq!(client.try_remove_watcher(&admin, &w2).unwrap(), Ok(()));
-        assert_eq!(client.try_remove_watcher(&admin, &w3).unwrap(), Ok(()));
-        assert_eq!(client.get_watchers().len(), 0);
+        assert_eq!(client.get_watchers().len(), 1);
+
+        // ...but removing the last remaining watcher is rejected.
+        assert_eq!(
+            client
+                .try_remove_watcher(&admin, &w3)
+                .unwrap_err()
+                .unwrap(),
+            ContractError::BelowMinWatchers
+        );
+        assert_eq!(client.get_watchers().len(), 1);
     }
 
     // 10. get_admin returns correct admin
@@ -789,11 +821,15 @@ mod tests {
         assert_eq!(client.try_register_watcher(&admin, &w3).unwrap(), Ok(()));
         assert_eq!(client.get_watchers().len(), 3);
 
-        assert_eq!(client.try_clear_all_watchers(&admin).unwrap(), Ok(()));
-        assert_eq!(client.get_watchers().len(), 0);
-        assert!(!client.is_authorized(&w1));
-        assert!(!client.is_authorized(&w2));
-        assert!(!client.is_authorized(&w3));
+        // With MIN_WATCHERS enforced, clearing a non-empty registry is rejected.
+        assert_eq!(
+            client.try_clear_all_watchers(&admin).unwrap_err().unwrap(),
+            ContractError::BelowMinWatchers
+        );
+        assert_eq!(client.get_watchers().len(), 3);
+        assert!(client.is_authorized(&w1));
+        assert!(client.is_authorized(&w2));
+        assert!(client.is_authorized(&w3));
     }
 
     // 13. clear_all_watchers rejects non-admin
@@ -909,6 +945,54 @@ mod tests {
         let admins = client.get_admins();
         assert_eq!(admins.len(), 2);
         assert!(vec_contains(&admins, &second_admin));
+    }
+
+    // MIN_WATCHERS — remove_watcher refuses to drop below the threshold
+    #[test]
+    fn test_remove_watcher_below_min_watchers_rejected() {
+        let (env, admin, client) = setup();
+        let watcher = Address::generate(&env);
+
+        assert_eq!(
+            client.try_register_watcher(&admin, &watcher).unwrap(),
+            Ok(())
+        );
+        assert_eq!(
+            client
+                .try_remove_watcher(&admin, &watcher)
+                .unwrap_err()
+                .unwrap(),
+            ContractError::BelowMinWatchers
+        );
+        assert!(client.is_watcher_authorized(&watcher));
+    }
+
+    // MIN_WATCHERS — removing down to exactly the threshold is allowed
+    #[test]
+    fn test_remove_watcher_down_to_min_watchers_allowed() {
+        let (env, admin, client) = setup();
+        let w1 = Address::generate(&env);
+        let w2 = Address::generate(&env);
+
+        client.register_watcher(&admin, &w1);
+        client.register_watcher(&admin, &w2);
+
+        assert_eq!(client.try_remove_watcher(&admin, &w1).unwrap(), Ok(()));
+        assert_eq!(client.get_watchers().len(), 1);
+    }
+
+    // MIN_WATCHERS — clear_all_watchers rejected while any watcher remains
+    #[test]
+    fn test_clear_all_watchers_below_min_watchers_rejected() {
+        let (env, admin, client) = setup();
+        let watcher = Address::generate(&env);
+
+        client.register_watcher(&admin, &watcher);
+
+        assert_eq!(
+            client.try_clear_all_watchers(&admin).unwrap_err().unwrap(),
+            ContractError::BelowMinWatchers
+        );
     }
 
     // 13. add_admin — second admin can perform privileged operations

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -28,6 +28,7 @@ The `WatcherRegistry` contract stores a set of authorized watcher node addresses
 
 - **Unauthorized watcher registration.** Only the current admin can call `register_watcher` or `remove_watcher`. Any unsigned or incorrectly signed call is rejected at the protocol level.
 - **Admin hijacking via direct call.** `transfer_admin` requires the current admin's auth signature, preventing an attacker from reassigning admin without controlling the current admin key.
+- **A single admin unilaterally stripping co-admins.** In a multi-admin set, `transfer_admin` only ever replaces the *caller's own* slot in the admin set — it cannot touch other admins' entries. An admin wanting to remove another admin must use `remove_admin`, which is a separate, individually-authorized call per target and still refuses to remove the last remaining admin. This means no single admin (even a compromised one) can use `transfer_admin` to seize sole control of a multi-admin registry.
 - **Replay attacks.** Stellar's sequence number mechanism prevents replaying previously valid transactions.
 
 ---
@@ -49,8 +50,8 @@ The `WatcherRegistry` contract stores a set of authorized watcher node addresses
 **Outcome:** Rejected by `require_auth()`. No state change.
 
 ### 2. Admin key is compromised
-**Vector:** Attacker obtains the admin private key and calls `register_watcher` or `transfer_admin`.  
-**Outcome:** Attacker gains full control of the registry. **Mitigation outside contract scope** — use hardware wallets, multi-sig accounts, or key rotation procedures.
+**Vector:** Attacker obtains an admin private key and calls `register_watcher`, `add_admin`, or `transfer_admin`.  
+**Outcome:** In a single-admin registry, the attacker gains full control. In a multi-admin registry, `transfer_admin` only replaces the *compromised admin's own* slot — the attacker cannot use it to strip other admins, though they can still add new admins via `add_admin` or perform any other privileged action available to a single admin. **Mitigation outside contract scope** — use hardware wallets, multi-sig accounts, or key rotation procedures; other admins can call `remove_admin` to revoke the compromised key's access.
 
 ### 3. Authorized watcher goes rogue
 **Vector:** A legitimately registered watcher node starts sending false or malicious alerts.  
@@ -68,6 +69,7 @@ The `WatcherRegistry` contract stores a set of authorized watcher node addresses
 |---|---|
 | Only admin can modify the registry | ✅ |
 | Admin transfer requires current admin auth | ✅ |
+| `transfer_admin` cannot strip other admins in a multi-admin set | ✅ |
 | Replay protection | ✅ (Stellar protocol) |
 | Admin key compromise protection | ❌ |
 | Off-chain watcher behavior enforcement | ❌ |

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -29,6 +29,7 @@ The `WatcherRegistry` contract stores a set of authorized watcher node addresses
 - **Unauthorized watcher registration.** Only the current admin can call `register_watcher` or `remove_watcher`. Any unsigned or incorrectly signed call is rejected at the protocol level.
 - **Admin hijacking via direct call.** `transfer_admin` requires the current admin's auth signature, preventing an attacker from reassigning admin without controlling the current admin key.
 - **A single admin unilaterally stripping co-admins.** In a multi-admin set, `transfer_admin` only ever replaces the *caller's own* slot in the admin set — it cannot touch other admins' entries. An admin wanting to remove another admin must use `remove_admin`, which is a separate, individually-authorized call per target and still refuses to remove the last remaining admin. This means no single admin (even a compromised one) can use `transfer_admin` to seize sole control of a multi-admin registry.
+- **Total loss of watcher monitoring via admin action.** `remove_watcher` and `clear_all_watchers` both refuse to drop the registered watcher count below `MIN_WATCHERS` (currently `1`). A malicious or compromised admin can still remove watchers down to that floor, but cannot fully halt the monitoring system through these entrypoints.
 - **Replay attacks.** Stellar's sequence number mechanism prevents replaying previously valid transactions.
 
 ---
@@ -39,7 +40,7 @@ The `WatcherRegistry` contract stores a set of authorized watcher node addresses
 - **Malicious behavior by authorized watchers.** Once a watcher is registered, the contract has no visibility into what that node does off-chain (e.g., sending false alerts, ignoring events).
 - **Front-running.** Because Stellar transactions are public before finalization, an observer could attempt to front-run an admin action, though the practical impact is low given the permissioned nature of the registry.
 - **Social engineering of the admin.** The contract cannot prevent an admin from being tricked into registering a malicious watcher address.
-- **Denial of service.** A malicious admin (or compromised key) could remove all watchers, halting the monitoring system. No minimum-watcher-count enforcement exists.
+- **Partial denial of service down to the minimum.** A malicious admin (or compromised key) can still remove watchers down to `MIN_WATCHERS`, degrading monitoring coverage even though the system cannot be fully halted via `remove_watcher`/`clear_all_watchers`.
 
 ---
 
@@ -58,8 +59,8 @@ The `WatcherRegistry` contract stores a set of authorized watcher node addresses
 **Outcome:** The contract cannot detect this. **Mitigation:** Admin removes the watcher via `remove_watcher`; off-chain monitoring of watcher behavior is required.
 
 ### 4. Admin removes all watchers (accidental or malicious)
-**Vector:** Admin calls `remove_watcher` for every registered address.  
-**Outcome:** No watchers remain; the monitoring system stops functioning. **Mitigation outside contract scope** — operational procedures and alerts on registry changes.
+**Vector:** Admin calls `remove_watcher` repeatedly, or `clear_all_watchers`, attempting to deauthorize every registered address.  
+**Outcome:** Both entrypoints refuse to drop the watcher count below `MIN_WATCHERS` (`1` by default) — `clear_all_watchers` is rejected outright while any watcher remains, and the final `remove_watcher` call below the floor returns `ContractError::BelowMinWatchers`. The last watcher cannot be removed through these calls, so monitoring can be degraded but not fully halted this way.
 
 ---
 
@@ -70,6 +71,7 @@ The `WatcherRegistry` contract stores a set of authorized watcher node addresses
 | Only admin can modify the registry | ✅ |
 | Admin transfer requires current admin auth | ✅ |
 | `transfer_admin` cannot strip other admins in a multi-admin set | ✅ |
+| Minimum watcher count enforced on removal | ✅ (`MIN_WATCHERS`) |
 | Replay protection | ✅ (Stellar protocol) |
 | Admin key compromise protection | ❌ |
 | Off-chain watcher behavior enforcement | ❌ |

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -36,11 +36,17 @@ The `WatcherRegistry` contract stores a set of authorized watcher node addresses
 
 ## What the Contract Does NOT Protect Against
 
-- **Compromised admin key.** If the admin keypair is stolen, an attacker can register arbitrary watchers or transfer admin to themselves. No multi-sig or time-lock is enforced at the contract level.
+- **Compromised admin key.** If the admin keypair is stolen, an attacker can register arbitrary watchers or transfer their own admin slot to themselves under a new key. No multi-sig or time-lock is enforced at the contract level. As a stopgap, any admin can call `pause` to freeze all state-mutating entrypoints while the incident is investigated — see [Pause / circuit-breaker](#pause--circuit-breaker) below.
 - **Malicious behavior by authorized watchers.** Once a watcher is registered, the contract has no visibility into what that node does off-chain (e.g., sending false alerts, ignoring events).
 - **Front-running.** Because Stellar transactions are public before finalization, an observer could attempt to front-run an admin action, though the practical impact is low given the permissioned nature of the registry.
 - **Social engineering of the admin.** The contract cannot prevent an admin from being tricked into registering a malicious watcher address.
 - **Partial denial of service down to the minimum.** A malicious admin (or compromised key) can still remove watchers down to `MIN_WATCHERS`, degrading monitoring coverage even though the system cannot be fully halted via `remove_watcher`/`clear_all_watchers`.
+
+---
+
+## Pause / circuit-breaker
+
+Both `WatcherRegistry` and `AlertRegistry` expose an admin-gated `pause` / `unpause` pair and a `paused` instance flag. While paused, every state-mutating entrypoint — including admin-management calls like `add_admin`/`remove_admin`/`transfer_admin` — returns `ContractError::Paused`; only `pause`/`unpause` themselves and read-only queries remain callable. This is intended purely as an emergency freeze — e.g. to stop further damage the moment a compromise is suspected — not as a routine operational control. Resolving the underlying compromise (rotating or removing the affected admin) still requires unpausing first.
 
 ---
 
@@ -52,7 +58,7 @@ The `WatcherRegistry` contract stores a set of authorized watcher node addresses
 
 ### 2. Admin key is compromised
 **Vector:** Attacker obtains an admin private key and calls `register_watcher`, `add_admin`, or `transfer_admin`.  
-**Outcome:** In a single-admin registry, the attacker gains full control. In a multi-admin registry, `transfer_admin` only replaces the *compromised admin's own* slot — the attacker cannot use it to strip other admins, though they can still add new admins via `add_admin` or perform any other privileged action available to a single admin. **Mitigation outside contract scope** — use hardware wallets, multi-sig accounts, or key rotation procedures; other admins can call `remove_admin` to revoke the compromised key's access.
+**Outcome:** In a single-admin registry, the attacker gains full control. In a multi-admin registry, `transfer_admin` only replaces the *compromised admin's own* slot — the attacker cannot use it to strip other admins, though they can still add new admins via `add_admin` or perform any other privileged action available to a single admin. **Mitigation:** Any other admin can call `pause` immediately to freeze all mutations (including further `add_admin`/`transfer_admin` calls) while the compromised key is rotated out via `remove_admin`; hardware wallets, multi-sig accounts, or key rotation procedures remain the first line of defense outside the contract.
 
 ### 3. Authorized watcher goes rogue
 **Vector:** A legitimately registered watcher node starts sending false or malicious alerts.  
@@ -61,6 +67,10 @@ The `WatcherRegistry` contract stores a set of authorized watcher node addresses
 ### 4. Admin removes all watchers (accidental or malicious)
 **Vector:** Admin calls `remove_watcher` repeatedly, or `clear_all_watchers`, attempting to deauthorize every registered address.  
 **Outcome:** Both entrypoints refuse to drop the watcher count below `MIN_WATCHERS` (`1` by default) — `clear_all_watchers` is rejected outright while any watcher remains, and the final `remove_watcher` call below the floor returns `ContractError::BelowMinWatchers`. The last watcher cannot be removed through these calls, so monitoring can be degraded but not fully halted this way.
+
+### 5. Incident response while a compromise is suspected
+**Vector:** An admin observes suspicious registry activity and wants to stop further damage before finishing the investigation.  
+**Outcome:** Any admin can call `pause`, which immediately rejects all state-mutating calls (on both `WatcherRegistry` and `AlertRegistry`) with `ContractError::Paused` while leaving all reads available. Once the compromised admin is identified and removed, an admin calls `unpause` to resume normal operation.
 
 ---
 
@@ -72,7 +82,8 @@ The `WatcherRegistry` contract stores a set of authorized watcher node addresses
 | Admin transfer requires current admin auth | ✅ |
 | `transfer_admin` cannot strip other admins in a multi-admin set | ✅ |
 | Minimum watcher count enforced on removal | ✅ (`MIN_WATCHERS`) |
+| Emergency pause / circuit-breaker on mutations | ✅ |
 | Replay protection | ✅ (Stellar protocol) |
-| Admin key compromise protection | ❌ |
+| Admin key compromise protection | ❌ (mitigated via `pause` + `remove_admin`, not prevented) |
 | Off-chain watcher behavior enforcement | ❌ |
 | Multi-sig / time-lock on admin actions | ❌ |

--- a/docs/watcher-registry.md
+++ b/docs/watcher-registry.md
@@ -131,6 +131,18 @@ Returns the current admin address.
 
 ---
 
+## Consumers
+
+### `AlertRegistry`
+
+`AlertRegistry` can be configured to gate its own read queries on this registry. When an admin calls `AlertRegistry::set_watcher_registry` with this contract's address, `AlertRegistry`'s `get_alerts_for_contract`, `get_alerts_by_owner`, and their paginated variants perform a cross-contract call to `is_watcher_authorized` before returning data, rejecting callers that are not registered watchers with `ContractError::NotAWatcher`.
+
+Gating is optional and off by default — if no watcher registry address is configured on `AlertRegistry`, these reads are unrestricted. See `docs/alert-registry.md`'s [`set_watcher_registry`](./alert-registry.md#set_watcher_registry) for the consumer-side configuration.
+
+Because gating is a live cross-contract read, removing a watcher here (via `remove_watcher`, `replace_watcher`, or `clear_all_watchers`) takes effect immediately for any `AlertRegistry` deployment that has gating enabled — there is no caching or delay on the consumer side.
+
+---
+
 ## Storage
 
 All state is stored in **instance storage**:


### PR DESCRIPTION
Summary
Addresses four watcher-registry / cross-contract issues:

#47 — Documents the AlertRegistry ↔ WatcherRegistry consumer relationship in docs/watcher-registry.md.
#49 — Fixes transfer_admin so a single admin can no longer wipe out every other admin in a multi-admin set; it now only replaces the caller's own slot.
#53 — Adds a MIN_WATCHERS floor (currently 1) that remove_watcher and clear_all_watchers cannot drop below, closing the "no minimum watcher count" gap called out in the threat model.
#55 — Adds an admin-gated pause/unpause circuit-breaker to both WatcherRegistry and AlertRegistry; every state-mutating entrypoint now rejects calls with ContractError::Paused while paused, and reads remain available.
docs/threat-model.md is updated throughout to reflect all three governance changes (#49, #53, #55).

Changes by commit
docs(watcher-registry): document AlertRegistry consumer integration
fix(watcher-registry): prevent transfer_admin from stripping co-admins
feat(watcher-registry): enforce a minimum watcher count
feat: add pause/circuit-breaker mechanism to both contracts
Notes
No rust toolchain was available in this environment, so these changes could not be built, linted, or tested locally. Please make sure cargo build, cargo test --workspace, and cargo clippy --workspace --all-targets -- -D warnings all pass in CI before merging.
clear_all_watchers and the tail end of remove_watcher change behavior intentionally per #53 — existing tests that exercised "clear registry to zero watchers" were updated to assert the new BelowMinWatchers rejection instead.
Pause gating was applied to every state-mutating entrypoint, including admin-management calls (add_admin/remove_admin/transfer_admin) — while paused, resolving an admin compromise requires unpausing first. This is called out in the updated threat model.
Scope was kept to what these four issues asked for — no unrelated cleanup, and generated TS bindings under bindings/ were left untouched since they're produced by the existing publish-bindings workflow, not hand-maintained.
Test plan
 cargo test --workspace (added/updated tests: transfer_admin multi-admin behavior, MIN_WATCHERS boundary cases for remove_watcher/clear_all_watchers, pause/unpause blocking mutations while allowing reads, on both contracts)
 cargo clippy --workspace --all-targets -- -D warnings
 cargo fmt --check
Closes #47
Closes #49
Closes #53
Closes #55