### PR TITLE
feat: add verify, upgrade, and audit targets to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test lint fmt check-events deploy-testnet bindings clean
+.PHONY: build test lint fmt check-events deploy-testnet verify upgrade audit bindings clean
 
 build:
 	cargo build --release --target wasm32-unknown-unknown --locked -p alert-registry -p watcher-registry
@@ -17,6 +17,20 @@ check-events:
 
 deploy-testnet:
 	bash scripts/deploy.sh
+
+# Verify a deployed contract against local build.
+# Usage: CONTRACT=alert-registry CONTRACT_ID=CXXX... [NETWORK=testnet] make verify
+verify:
+	bash scripts/verify.sh $(if $(CONTRACT),--contract $(CONTRACT)) $(if $(CONTRACT_ID),--contract-id $(CONTRACT_ID)) $(if $(NETWORK),--network $(NETWORK))
+
+# Upgrade a deployed contract on-chain.
+# Usage: CONTRACT=alert-registry CONTRACT_ID=CXXX... [NETWORK=testnet] make upgrade
+upgrade:
+	bash scripts/upgrade.sh $(if $(CONTRACT),--contract $(CONTRACT)) $(if $(CONTRACT_ID),--contract-id $(CONTRACT_ID)) $(if $(NETWORK),--network $(NETWORK))
+
+# Run cargo audit dependency vulnerability scan.
+audit:
+	cargo audit
 
 # Generate TypeScript bindings for WatcherRegistry.
 # Requires: stellar CLI on PATH and a prior `make build`.


### PR DESCRIPTION
## Description

This PR introduces entrypoint targets in `Makefile` for verification, upgrade, and audit tasks:

- Added `verify` target wrapping `scripts/verify.sh` with optional `CONTRACT`, `CONTRACT_ID`, and `NETWORK` parameters.
- Added `upgrade` target wrapping `scripts/upgrade.sh` with optional parameters.
- Added `audit` target wrapping `cargo audit` for scanning dependency vulnerabilities locally.
- Updated `.PHONY` list to include `verify`, `upgrade`, and `audit`.

Closes #97