### PR TITLE
fix(ci): optimize WASM binary before measuring in wasm-size-check.yml

### DIFF
--- a/.github/workflows/wasm-size-check.yml
+++ b/.github/workflows/wasm-size-check.yml
@@ -7,7 +7,7 @@ on:
     branches: ["**"]
 
 env:
-  WASM_SIZE_LIMIT_KB: 100
+  WASM_SIZE_LIMIT_KB: 60
 
 jobs:
   wasm-size:
@@ -32,15 +32,25 @@ jobs:
           toolchain: ${{ steps.rust.outputs.channel }}
           targets: wasm32-unknown-unknown
 
+      - name: Install Stellar CLI
+        run: cargo install --locked stellar-cli --features opt
+
       - name: Build WASM binaries
         run: cargo build --release --target wasm32-unknown-unknown --locked -p alert-registry -p watcher-registry
+
+      # Optimize contracts to match the deploy path (deploy.sh)
+      - name: Optimize WASM binaries
+        run: |
+          for w in alert_registry watcher_registry; do
+            stellar contract optimize --wasm "target/wasm32-unknown-unknown/release/$w.wasm"
+          done
 
       - name: Check binary sizes
         run: |
           LIMIT=$(( ${{ env.WASM_SIZE_LIMIT_KB }} * 1024 ))
           FAILED=0
 
-          for wasm in target/wasm32-unknown-unknown/release/*.wasm; do
+          for wasm in target/wasm32-unknown-unknown/release/*.optimized.wasm; do
             SIZE=$(stat -c%s "$wasm")
             SIZE_KB=$(( SIZE / 1024 ))
             echo "$wasm: ${SIZE_KB}KB"


### PR DESCRIPTION
## Description

This PR updates the `wasm-size-check.yml` workflow to measure the size of the optimized WASM artifact that is actually deployed:

- Added a step to install the Stellar CLI in the workflow environment.
- Added `stellar contract optimize` step across the contract crates, matching the deployment pipeline in `scripts/deploy.sh`.
- Updated size assertions to target `*.optimized.wasm` artifacts and adjusted `WASM_SIZE_LIMIT_KB` to reflect the optimized binary footprint.

Closes #95