### PR TITLE
refactor(lints): centralize clippy pedantic lints in [workspace.lints]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,16 @@ rust-version = "1.88"
 [workspace.dependencies]
 soroban-sdk = { version = "22.0.0" }
 
+[workspace.lints.clippy]
+pedantic = { level = "warn", priority = -1 }
+# Soroban's generated contract interface dictates these shapes, so the
+# corresponding pedantic lints fire on correct code and are scoped off here
+# rather than silenced case by case:
+#   - contract entry points must take `Env` and `Address` by value
+#   - `#[contractimpl]` re-exports getters, so `#[must_use]` is not ours to add
+needless_pass_by_value = "allow"
+must_use_candidate = "allow"
+
 [profile.release]
 opt-level = "z"
 overflow-checks = true

--- a/contracts/alert-registry/Cargo.toml
+++ b/contracts/alert-registry/Cargo.toml
@@ -12,6 +12,9 @@ documentation = "https://docs.rs/alert-registry"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[lints]
+workspace = true
+
 [features]
 testutils = ["soroban-sdk/testutils", "watcher-registry/testutils"]
 watcher-gating = ["watcher-registry"]

--- a/contracts/alert-registry/src/lib.rs
+++ b/contracts/alert-registry/src/lib.rs
@@ -1,11 +1,5 @@
 #![no_std]
-#![warn(clippy::pedantic)]
-// Soroban's generated contract interface dictates these shapes, so the
-// corresponding pedantic lints fire on correct code and are scoped off here
-// rather than silenced case by case:
-//   - contract entry points must take `Env` and `Address` by value
-//   - `#[contractimpl]` re-exports getters, so `#[must_use]` is not ours to add
-#![allow(clippy::needless_pass_by_value, clippy::must_use_candidate)]
+
 use soroban_sdk::{
     contract, contracterror, contractimpl, contractmeta, contracttype, panic_with_error,
     symbol_short, vec, Address, Env, String, Vec,

--- a/contracts/integration-tests/Cargo.toml
+++ b/contracts/integration-tests/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 rust-version.workspace = true
 
+[lints]
+workspace = true
+
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
 alert-registry = { path = "../alert-registry", features = ["testutils"] }

--- a/contracts/test-utils/Cargo.toml
+++ b/contracts/test-utils/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 rust-version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
 alert-registry = { path = "../alert-registry", features = ["testutils"] }

--- a/contracts/watcher-registry/Cargo.toml
+++ b/contracts/watcher-registry/Cargo.toml
@@ -12,6 +12,9 @@ documentation = "https://docs.rs/watcher-registry"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[lints]
+workspace = true
+
 [dependencies]
 soroban-sdk = { workspace = true }
 

--- a/contracts/watcher-registry/src/lib.rs
+++ b/contracts/watcher-registry/src/lib.rs
@@ -1,11 +1,5 @@
 #![no_std]
-#![warn(clippy::pedantic)]
-// Soroban's generated contract interface dictates these shapes, so the
-// corresponding pedantic lints fire on correct code and are scoped off here
-// rather than silenced case by case:
-//   - contract entry points must take `Env` and `Address` by value
-//   - `#[contractimpl]` re-exports getters, so `#[must_use]` is not ours to add
-#![allow(clippy::needless_pass_by_value, clippy::must_use_candidate)]
+
 use soroban_sdk::{
     contract, contracterror, contractimpl, contractmeta, contracttype, symbol_short, vec, Address,
     Env, Vec,


### PR DESCRIPTION
## Description
- Moved the pedantic lint configuration and interface-specific allowances into `[workspace.lints.clippy]` in the root `Cargo.toml`.
- Enabled `[lints] workspace = true` across all workspace member crates (`alert-registry`, `watcher-registry`, `integration-tests`, and `test-utils`).
- Removed redundant per-crate `#![warn(clippy::pedantic)]` and `#![allow(...)]` source attributes from `alert-registry/src/lib.rs` and `watcher-registry/src/lib.rs`.

## Related Issue
Closes #105

## Type of change
- Chore
- Refactoring

## Checklist
- [x] My code follows the repository style
- [x] I have updated or added documentation if necessary
- [x] All CI checks pass