### PR TITLE
ci: add PR dependency review and release SBOM generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,3 +87,15 @@ jobs:
 
       - name: Cargo audit
         run: cargo audit
+
+  # Issue #102 — PR-time dependency diffing and review
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4

--- a/.github/workflows/publish-abis.yml
+++ b/.github/workflows/publish-abis.yml
@@ -50,9 +50,19 @@ jobs:
             --wasm target/wasm32-unknown-unknown/release/watcher_registry.wasm \
             --output abi/watcher-registry.json
 
-      - name: Upload ABIs to release
+      - name: Install cargo-cyclonedx
+        run: cargo install cargo-cyclonedx --locked
+
+      - name: Generate CycloneDX SBOM
+        run: |
+          mkdir -p sbom
+          cargo cyclonedx --format json --all
+          find . -name "*.cdx.json" -exec cp {} sbom/ \;
+
+      - name: Upload ABIs and SBOMs to release
         uses: softprops/action-gh-release@v2
         with:
           files: |
             abi/alert-registry.json
             abi/watcher-registry.json
+            sbom/*.cdx.json


### PR DESCRIPTION
## Description
- Added `actions/dependency-review-action@v4` to `.github/workflows/ci.yml` to gate on dependency vulnerabilities and licensing changes on pull requests.
- Added `cargo-cyclonedx` SBOM generation step to `.github/workflows/publish-abis.yml` release workflow to generate and upload CycloneDX SBOMs with release assets.

## Related Issue
Closes #102

## Type of change
- CI / Hygiene
- Security

## Checklist
- [x] My code follows the repository style
- [x] I have updated or added documentation if necessary
- [x] All CI checks pass