### PR TITLE
Feature/alert registry enhancements

### DIFF
--- a/contracts/alert-registry/src/lib.rs
+++ b/contracts/alert-registry/src/lib.rs
@@ -717,6 +717,59 @@ impl AlertRegistry {
         Ok(())
     }
 
+    /// Deactivate an alert without deleting its record (admin only).
+    ///
+    /// Unlike [`Self::remove_alert_by_admin`], the alert config and its
+    /// indexes are left intact — only the `active` flag is cleared — so
+    /// history is preserved for e.g. spam/abuse moderation.
+    ///
+    /// # Auth
+    /// Requires a valid Stellar auth signature from `admin`.
+    /// # Errors
+    /// Returns [`ContractError::AlertNotFound`] if `config_id` does not identify an existing alert.
+    /// Returns [`ContractError::NotInitialized`] if the contract has not been initialized.
+    /// Returns [`ContractError::Unauthorized`] if the caller is not authorized for this operation.
+    /// # Events
+    /// Emits `(Symbol("alert"), Symbol("admin_off"))` with data `(id: u64, admin: Address)`.
+    pub fn deactivate_alert_by_admin(
+        env: Env,
+        admin: Address,
+        config_id: u64,
+    ) -> Result<(), ContractError> {
+        admin.require_auth();
+        Self::assert_admin(&env, &admin)?;
+
+        let mut config: AlertConfig = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Alert(config_id))
+            .ok_or(ContractError::AlertNotFound)?;
+
+        config.active = false;
+        config.updated_at = env.ledger().timestamp();
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Alert(config_id), &config);
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::Alert(config_id), DEFAULT_TTL, DEFAULT_TTL);
+        env.storage()
+            .persistent()
+            .set(&DataKey::AlertActive(config_id), &false);
+        env.storage().persistent().extend_ttl(
+            &DataKey::AlertActive(config_id),
+            DEFAULT_TTL,
+            DEFAULT_TTL,
+        );
+
+        env.events().publish(
+            (symbol_short!("alert"), symbol_short!("admin_off")),
+            (config_id, admin),
+        );
+        Ok(())
+    }
+
     /// Transfer ownership of an alert to a new address.
     ///
     /// Updates the [`AlertConfig::owner`] field and migrates the alert ID from

--- a/contracts/alert-registry/src/lib.rs
+++ b/contracts/alert-registry/src/lib.rs
@@ -253,7 +253,10 @@ impl AlertRegistry {
     ///
     /// Once set, `get_alerts_for_contract`, `get_alerts_by_owner`, and their
     /// paginated variants will cross-call `WatcherRegistry::is_watcher_authorized`
-    /// before returning data. Pass the zero address to disable gating.
+    /// before returning data. Any address configured here — including a
+    /// zero/default `Address` — is treated as a real registry and will be
+    /// cross-called. Use [`AlertRegistry::clear_watcher_registry`] to disable
+    /// gating.
     ///
     /// # Auth
     /// Requires a valid Stellar auth signature from `admin`.
@@ -270,6 +273,26 @@ impl AlertRegistry {
         env.storage()
             .instance()
             .set(&symbol_short!("WATCHREG"), &watcher_registry);
+        Ok(())
+    }
+
+    /// Clear the configured `WatcherRegistry` contract address, disabling
+    /// watcher-gating on the read queries (admin only).
+    ///
+    /// After this call, `get_alerts_for_contract`, `get_alerts_by_owner`, and
+    /// their paginated variants no longer cross-call `WatcherRegistry` and
+    /// behave as if gating had never been configured. Call
+    /// [`AlertRegistry::set_watcher_registry`] again to re-enable gating.
+    ///
+    /// # Auth
+    /// Requires a valid Stellar auth signature from `admin`.
+    /// # Errors
+    /// Returns [`ContractError::NotInitialized`] if the contract has not been initialized.
+    /// Returns [`ContractError::Unauthorized`] if the caller is not authorized for this operation.
+    pub fn clear_watcher_registry(env: Env, admin: Address) -> Result<(), ContractError> {
+        admin.require_auth();
+        Self::assert_admin(&env, &admin)?;
+        env.storage().instance().remove(&symbol_short!("WATCHREG"));
         Ok(())
     }
 
@@ -2109,6 +2132,107 @@ mod tests {
                 .unwrap_err()
                 .unwrap(),
             ContractError::Unauthorized
+        );
+    }
+
+    // 17b. clear_watcher_registry disables gating; set_watcher_registry can
+    // re-enable it afterward.
+    #[test]
+    #[cfg(feature = "testutils")]
+    fn test_clear_watcher_registry_disables_then_reconfigure() {
+        let (env, alert_client, watcher_client) = setup_with_watcher_registry();
+
+        let admin = Address::generate(&env);
+        let watcher = Address::generate(&env);
+        let stranger = Address::generate(&env);
+        let owner = Address::generate(&env);
+        let target = Address::generate(&env);
+
+        watcher_client.initialize(&admin);
+        watcher_client.register_watcher(&admin, &watcher);
+
+        alert_client.initialize(&admin);
+        let watcher_contract_id = watcher_client.address.clone();
+        alert_client.set_watcher_registry(&admin, &watcher_contract_id);
+        assert!(alert_client.is_watcher_gating_enabled());
+
+        alert_client.register_alert(
+            &owner,
+            &target,
+            &str(&env, "Alert"),
+            &hash64(&env),
+            &vec![&env],
+        );
+
+        // Gating active: unregistered querier is rejected.
+        assert_eq!(
+            alert_client
+                .try_get_alerts_for_contract(&stranger, &target)
+                .unwrap_err()
+                .unwrap(),
+            ContractError::NotAWatcher
+        );
+
+        // Clear gating.
+        alert_client.clear_watcher_registry(&admin);
+        assert!(alert_client.get_watcher_registry().is_none());
+        assert!(!alert_client.is_watcher_gating_enabled());
+
+        // Any querier can now read.
+        assert_eq!(
+            alert_client
+                .get_alerts_for_contract(&stranger, &target)
+                .len(),
+            1
+        );
+
+        // Re-configure gating.
+        alert_client.set_watcher_registry(&admin, &watcher_contract_id);
+        assert!(alert_client.is_watcher_gating_enabled());
+        assert_eq!(
+            alert_client
+                .try_get_alerts_for_contract(&stranger, &target)
+                .unwrap_err()
+                .unwrap(),
+            ContractError::NotAWatcher
+        );
+        assert_eq!(
+            alert_client
+                .get_alerts_for_contract(&watcher, &target)
+                .len(),
+            1
+        );
+    }
+
+    // 17c. clear_watcher_registry rejects non-admin callers.
+    #[test]
+    fn test_clear_watcher_registry_non_admin_rejected() {
+        let (env, client) = setup();
+        let admin = Address::generate(&env);
+        let attacker = Address::generate(&env);
+        client.initialize(&admin);
+
+        assert_eq!(
+            client
+                .try_clear_watcher_registry(&attacker)
+                .unwrap_err()
+                .unwrap(),
+            ContractError::Unauthorized
+        );
+    }
+
+    // 17d. clear_watcher_registry requires the contract to be initialized.
+    #[test]
+    fn test_clear_watcher_registry_not_initialized() {
+        let (env, client) = setup();
+        let admin = Address::generate(&env);
+
+        assert_eq!(
+            client
+                .try_clear_watcher_registry(&admin)
+                .unwrap_err()
+                .unwrap(),
+            ContractError::NotInitialized
         );
     }
 

--- a/contracts/alert-registry/src/lib.rs
+++ b/contracts/alert-registry/src/lib.rs
@@ -112,6 +112,25 @@ pub struct AlertConfig {
     pub active: bool,
 }
 
+/// Input record for [`AlertRegistry::batch_register_alert`].
+///
+/// Mirrors the arguments of [`AlertRegistry::register_alert`] so a batch call
+/// can register alerts for multiple owners/targets in one transaction.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct AlertInput {
+    /// Address that will own and control this alert.
+    pub owner: Address,
+    /// Contract address to watch.
+    pub target_contract: Address,
+    /// Human-readable name for the alert.
+    pub label: String,
+    /// SHA-256 hash of the destination webhook URL.
+    pub webhook_hash: String,
+    /// Rule identifiers that should trigger the alert.
+    pub rules: Vec<String>,
+}
+
 // ── Contract ─────────────────────────────────────────────────────────────────
 
 /// On-chain registry for alert configurations.
@@ -818,6 +837,76 @@ impl AlertRegistry {
             (symbol_short!("alert"), symbol_short!("transfer")),
             (config_id, old_owner, new_owner),
         );
+        Ok(())
+    }
+
+    /// Register multiple alert configs in a single call.
+    ///
+    /// Each input is validated and authorized exactly as
+    /// [`Self::register_alert`] would, and each successful registration emits
+    /// the same `(Symbol("alert"), Symbol("register"))` event. If any input
+    /// fails validation or authorization, the entire batch (including any
+    /// alerts already registered earlier in the same call) is rolled back,
+    /// since Soroban invocations are atomic.
+    ///
+    /// # Auth
+    /// Requires a valid Stellar auth signature from each input's `owner`.
+    ///
+    /// # Returns
+    /// The new alerts' numeric IDs, in the same order as `inputs`.
+    /// # Errors
+    /// Returns the same errors as [`Self::register_alert`] for the failing item.
+    pub fn batch_register_alert(
+        env: Env,
+        inputs: Vec<AlertInput>,
+    ) -> Result<Vec<u64>, ContractError> {
+        let mut ids: Vec<u64> = vec![&env];
+        for i in 0..inputs.len() {
+            let input = inputs.get(i).unwrap();
+            let id = Self::register_alert(
+                env.clone(),
+                input.owner,
+                input.target_contract,
+                input.label,
+                input.webhook_hash,
+                input.rules,
+            )?;
+            ids.push_back(id);
+        }
+        Ok(ids)
+    }
+
+    /// Remove multiple alert configs owned by `caller` in a single call.
+    ///
+    /// Each ID is validated and authorized exactly as [`Self::remove_alert`]
+    /// would, and each successful removal emits the same
+    /// `(Symbol("alert"), Symbol("remove"))` event. If any ID does not exist
+    /// or is not owned by `caller`, the entire batch is rolled back, since
+    /// Soroban invocations are atomic.
+    ///
+    /// # Auth
+    /// Requires a valid Stellar auth signature from `caller`.
+    /// # Errors
+    /// Returns [`ContractError::AlertNotFound`] if any `config_ids` entry does not identify an existing alert.
+    /// Returns [`ContractError::Unauthorized`] if `caller` does not own every alert in `config_ids`.
+    pub fn batch_remove_alert(
+        env: Env,
+        caller: Address,
+        config_ids: Vec<u64>,
+    ) -> Result<(), ContractError> {
+        caller.require_auth();
+
+        for i in 0..config_ids.len() {
+            let config_id = config_ids.get(i).unwrap();
+            let config: AlertConfig = env
+                .storage()
+                .persistent()
+                .get(&DataKey::Alert(config_id))
+                .ok_or(ContractError::AlertNotFound)?;
+
+            Self::assert_owner(&config, &caller)?;
+            Self::remove_alert_record(&env, &config, config_id, &caller);
+        }
         Ok(())
     }
 

--- a/contracts/alert-registry/src/lib.rs
+++ b/contracts/alert-registry/src/lib.rs
@@ -717,6 +717,57 @@ impl AlertRegistry {
         Ok(())
     }
 
+    /// Transfer ownership of an alert to a new address.
+    ///
+    /// Updates the [`AlertConfig::owner`] field and migrates the alert ID from
+    /// the old owner's [`DataKey::OwnerIndex`] to the new owner's.
+    ///
+    /// # Auth
+    /// Requires a valid Stellar auth signature from `caller`, who must be the
+    /// current owner of the alert.
+    /// # Errors
+    /// Returns [`ContractError::AlertNotFound`] if `config_id` does not identify an existing alert.
+    /// Returns [`ContractError::Unauthorized`] if `caller` is not the current owner.
+    /// # Events
+    /// Emits `(Symbol("alert"), Symbol("transfer"))` with data
+    /// `(id: u64, old_owner: Address, new_owner: Address)`.
+    pub fn transfer_alert_ownership(
+        env: Env,
+        caller: Address,
+        config_id: u64,
+        new_owner: Address,
+    ) -> Result<(), ContractError> {
+        caller.require_auth();
+
+        let mut config: AlertConfig = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Alert(config_id))
+            .ok_or(ContractError::AlertNotFound)?;
+
+        Self::assert_owner(&config, &caller)?;
+
+        let old_owner = config.owner.clone();
+        config.owner = new_owner.clone();
+        config.updated_at = env.ledger().timestamp();
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Alert(config_id), &config);
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::Alert(config_id), DEFAULT_TTL, DEFAULT_TTL);
+
+        Self::remove_from_owner_index(&env, &old_owner, config_id);
+        Self::push_owner_index(&env, &new_owner, config_id)?;
+
+        env.events().publish(
+            (symbol_short!("alert"), symbol_short!("transfer")),
+            (config_id, old_owner, new_owner),
+        );
+        Ok(())
+    }
+
     /// Extend the TTL of an alert and its associated indexes.
     ///
     /// Callers may request any TTL up to [`MAX_TTL`] ledgers.  Values above

--- a/contracts/alert-registry/src/tests.rs
+++ b/contracts/alert-registry/src/tests.rs
@@ -1235,3 +1235,95 @@ fn test_configs_paginated_boundaries() {
     let p5 = client.get_alerts_by_owner_paginated(&querier, &owner, &10, &2);
     assert_eq!(p5.len(), 0);
 }
+
+// ── Issue #34 — transfer_alert_ownership ────────────────────────────────
+
+#[test]
+fn test_transfer_alert_ownership_success() {
+    let (env, client) = setup();
+    let owner = Address::generate(&env);
+    let new_owner = Address::generate(&env);
+    let target = Address::generate(&env);
+
+    let id = client.register_alert(
+        &owner,
+        &target,
+        &str(&env, "Alert"),
+        &hash64(&env),
+        &vec![&env],
+    );
+
+    client.transfer_alert_ownership(&owner, &id, &new_owner);
+
+    let cfg = client.get_alert(&id).unwrap();
+    assert_eq!(cfg.owner, new_owner);
+
+    // OwnerIndex updated for both the old and new owner.
+    assert_eq!(client.get_alerts_by_owner(&new_owner, &owner).len(), 0);
+    let new_owner_alerts = client.get_alerts_by_owner(&new_owner, &new_owner);
+    assert_eq!(new_owner_alerts.len(), 1);
+    assert_eq!(new_owner_alerts.get(0).unwrap().owner, new_owner);
+}
+
+#[test]
+fn test_transfer_alert_ownership_unauthorized() {
+    let (env, client) = setup();
+    let owner = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let new_owner = Address::generate(&env);
+    let target = Address::generate(&env);
+
+    let id = client.register_alert(
+        &owner,
+        &target,
+        &str(&env, "Alert"),
+        &hash64(&env),
+        &vec![&env],
+    );
+
+    assert_eq!(
+        client
+            .try_transfer_alert_ownership(&attacker, &id, &new_owner)
+            .unwrap_err()
+            .unwrap(),
+        ContractError::Unauthorized
+    );
+
+    // Ownership and indexes are unchanged.
+    assert_eq!(client.get_alert(&id).unwrap().owner, owner);
+    assert_eq!(client.get_alerts_by_owner(&owner, &owner).len(), 1);
+}
+
+#[test]
+fn test_transfer_alert_ownership_not_found() {
+    let (env, client) = setup();
+    let caller = Address::generate(&env);
+    let new_owner = Address::generate(&env);
+
+    assert_eq!(
+        client
+            .try_transfer_alert_ownership(&caller, &999u64, &new_owner)
+            .unwrap_err()
+            .unwrap(),
+        ContractError::AlertNotFound
+    );
+}
+
+#[test]
+fn test_transfer_alert_ownership_emits_event() {
+    let (env, client) = setup();
+    let owner = Address::generate(&env);
+    let new_owner = Address::generate(&env);
+    let target = Address::generate(&env);
+
+    let id = client.register_alert(
+        &owner,
+        &target,
+        &str(&env, "Alert"),
+        &hash64(&env),
+        &vec![&env],
+    );
+
+    client.transfer_alert_ownership(&owner, &id, &new_owner);
+    assert!(!env.events().all().is_empty());
+}

--- a/contracts/alert-registry/src/tests.rs
+++ b/contracts/alert-registry/src/tests.rs
@@ -1327,3 +1327,92 @@ fn test_transfer_alert_ownership_emits_event() {
     client.transfer_alert_ownership(&owner, &id, &new_owner);
     assert!(!env.events().all().is_empty());
 }
+
+// ── Issue #36 — deactivate_alert_by_admin ───────────────────────────────
+
+#[test]
+fn test_deactivate_alert_by_admin_success() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let owner = Address::generate(&env);
+    let target = Address::generate(&env);
+    let id = client.register_alert(
+        &owner,
+        &target,
+        &str(&env, "Alert"),
+        &hash64(&env),
+        &vec![&env],
+    );
+
+    client.deactivate_alert_by_admin(&admin, &id);
+
+    // Record still exists (not deleted) but is inactive.
+    let cfg = client.get_alert(&id).unwrap();
+    assert!(!cfg.active);
+    assert_eq!(client.get_alert_active(&id), Some(false));
+}
+
+#[test]
+fn test_deactivate_alert_by_admin_unauthorized() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    client.initialize(&admin);
+
+    let owner = Address::generate(&env);
+    let target = Address::generate(&env);
+    let id = client.register_alert(
+        &owner,
+        &target,
+        &str(&env, "Alert"),
+        &hash64(&env),
+        &vec![&env],
+    );
+
+    assert_eq!(
+        client
+            .try_deactivate_alert_by_admin(&attacker, &id)
+            .unwrap_err()
+            .unwrap(),
+        ContractError::Unauthorized
+    );
+
+    assert!(client.get_alert(&id).unwrap().active);
+}
+
+#[test]
+fn test_deactivate_alert_by_admin_not_found() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    assert_eq!(
+        client
+            .try_deactivate_alert_by_admin(&admin, &999u64)
+            .unwrap_err()
+            .unwrap(),
+        ContractError::AlertNotFound
+    );
+}
+
+#[test]
+fn test_deactivate_alert_by_admin_emits_event() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let owner = Address::generate(&env);
+    let target = Address::generate(&env);
+    let id = client.register_alert(
+        &owner,
+        &target,
+        &str(&env, "Alert"),
+        &hash64(&env),
+        &vec![&env],
+    );
+
+    client.deactivate_alert_by_admin(&admin, &id);
+    assert!(!env.events().all().is_empty());
+}

--- a/contracts/alert-registry/src/tests.rs
+++ b/contracts/alert-registry/src/tests.rs
@@ -1,3 +1,4 @@
+use crate::AlertInput;
 use crate::AlertRegistry;
 use crate::AlertRegistryClient;
 use crate::ContractError;
@@ -1415,4 +1416,204 @@ fn test_deactivate_alert_by_admin_emits_event() {
 
     client.deactivate_alert_by_admin(&admin, &id);
     assert!(!env.events().all().is_empty());
+}
+
+// ── Issue #37 — batch_register_alert / batch_remove_alert ───────────────
+
+fn alert_input(env: &Env, owner: &Address, target: &Address, label: &str) -> AlertInput {
+    AlertInput {
+        owner: owner.clone(),
+        target_contract: target.clone(),
+        label: str(env, label),
+        webhook_hash: hash64(env),
+        rules: vec![env],
+    }
+}
+
+#[test]
+fn test_batch_register_alert_single() {
+    let (env, client) = setup();
+    let owner = Address::generate(&env);
+    let target = Address::generate(&env);
+
+    let inputs = vec![&env, alert_input(&env, &owner, &target, "A0")];
+
+    let ids = client.batch_register_alert(&inputs);
+    assert_eq!(ids.len(), 1);
+    assert!(client.get_alert(&ids.get(0).unwrap()).is_some());
+    assert_eq!(client.get_alert_count(), 1);
+}
+
+#[test]
+fn test_batch_register_alert_five() {
+    let (env, client) = setup();
+    let owner = Address::generate(&env);
+    let target = Address::generate(&env);
+
+    let mut inputs: Vec<AlertInput> = vec![&env];
+    for _ in 0..5u32 {
+        inputs.push_back(alert_input(&env, &owner, &target, "A"));
+    }
+
+    let ids = client.batch_register_alert(&inputs);
+    assert_eq!(ids.len(), 5);
+    assert_eq!(client.get_alert_count(), 5);
+    assert_eq!(client.get_active_alert_count(&owner), 5);
+}
+
+#[test]
+fn test_batch_register_alert_boundary_size() {
+    let (env, client) = setup();
+    let owner = Address::generate(&env);
+    let target = Address::generate(&env);
+
+    let mut inputs: Vec<AlertInput> = vec![&env];
+    for _ in 0..25u32 {
+        inputs.push_back(alert_input(&env, &owner, &target, "A"));
+    }
+
+    let ids = client.batch_register_alert(&inputs);
+    assert_eq!(ids.len(), 25);
+    assert_eq!(client.get_alert_count(), 25);
+    assert_eq!(client.get_active_alert_count(&owner), 25);
+}
+
+#[test]
+fn test_batch_register_alert_rolls_back_on_validation_error() {
+    let (env, client) = setup();
+    let owner = Address::generate(&env);
+    let target = Address::generate(&env);
+
+    let mut bad = alert_input(&env, &owner, &target, "Bad");
+    bad.webhook_hash = str(&env, "too-short");
+
+    let inputs = vec![
+        &env,
+        alert_input(&env, &owner, &target, "Good"),
+        bad,
+    ];
+
+    assert_eq!(
+        client
+            .try_batch_register_alert(&inputs)
+            .unwrap_err()
+            .unwrap(),
+        ContractError::InvalidWebhookHash
+    );
+    // The whole batch is rolled back, including the earlier valid item.
+    assert_eq!(client.get_alert_count(), 0);
+}
+
+#[test]
+fn test_batch_remove_alert_single() {
+    let (env, client) = setup();
+    let owner = Address::generate(&env);
+    let target = Address::generate(&env);
+
+    let id = client.register_alert(
+        &owner,
+        &target,
+        &str(&env, "A"),
+        &hash64(&env),
+        &vec![&env],
+    );
+
+    client.batch_remove_alert(&owner, &vec![&env, id]);
+    assert!(client.get_alert(&id).is_none());
+}
+
+#[test]
+fn test_batch_remove_alert_five() {
+    let (env, client) = setup();
+    let owner = Address::generate(&env);
+    let target = Address::generate(&env);
+
+    let mut ids: Vec<u64> = vec![&env];
+    for _ in 0..5u32 {
+        let id = client.register_alert(
+            &owner,
+            &target,
+            &str(&env, "A"),
+            &hash64(&env),
+            &vec![&env],
+        );
+        ids.push_back(id);
+    }
+
+    client.batch_remove_alert(&owner, &ids);
+    for i in 0..ids.len() {
+        assert!(client.get_alert(&ids.get(i).unwrap()).is_none());
+    }
+    assert_eq!(client.get_active_alert_count(&owner), 0);
+}
+
+#[test]
+fn test_batch_remove_alert_boundary_size() {
+    let (env, client) = setup();
+    let owner = Address::generate(&env);
+    let target = Address::generate(&env);
+
+    let mut ids: Vec<u64> = vec![&env];
+    for _ in 0..25u32 {
+        let id = client.register_alert(
+            &owner,
+            &target,
+            &str(&env, "A"),
+            &hash64(&env),
+            &vec![&env],
+        );
+        ids.push_back(id);
+    }
+
+    client.batch_remove_alert(&owner, &ids);
+    assert_eq!(client.get_active_alert_count(&owner), 0);
+}
+
+#[test]
+fn test_batch_remove_alert_unauthorized_rolls_back() {
+    let (env, client) = setup();
+    let owner = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let target = Address::generate(&env);
+
+    let id1 = client.register_alert(
+        &owner,
+        &target,
+        &str(&env, "A"),
+        &hash64(&env),
+        &vec![&env],
+    );
+    let id2 = client.register_alert(
+        &owner,
+        &target,
+        &str(&env, "B"),
+        &hash64c(&env, 'b'),
+        &vec![&env],
+    );
+
+    assert_eq!(
+        client
+            .try_batch_remove_alert(&attacker, &vec![&env, id1, id2])
+            .unwrap_err()
+            .unwrap(),
+        ContractError::Unauthorized
+    );
+
+    // Nothing removed.
+    assert!(client.get_alert(&id1).is_some());
+    assert!(client.get_alert(&id2).is_some());
+}
+
+#[test]
+fn test_batch_remove_alert_not_found() {
+    let (env, client) = setup();
+    let owner = Address::generate(&env);
+
+    assert_eq!(
+        client
+            .try_batch_remove_alert(&owner, &vec![&env, 999u64])
+            .unwrap_err()
+            .unwrap(),
+        ContractError::AlertNotFound
+    );
 }

--- a/docs/alert-registry.md
+++ b/docs/alert-registry.md
@@ -219,6 +219,27 @@ Removes any alert config by ID. Requires admin auth.
 **Returns:** nothing
 
 ---
+
+### `deactivate_alert_by_admin`
+
+Deactivates any alert by ID without deleting its record. Unlike `remove_alert_by_admin`, the alert config and its owner/contract indexes are left intact — only the `active` flag is cleared — so an admin can moderate a single problematic alert (spam, abuse report) while preserving its history. Admin only.
+
+**Requires auth:** `admin`
+
+**Parameters**
+
+| Name | Type | Description |
+|---|---|---|
+| `admin` | `Address` | Current admin address |
+| `config_id` | `u64` | ID of the alert to deactivate |
+
+**Returns:** nothing
+
+**Errors:** Returns `ContractError::AlertNotFound` if ID does not exist; `ContractError::Unauthorized` if caller is not the admin.
+
+**Events:** Emits `(Symbol("alert"), Symbol("admin_off"))` with data `(id: u64, admin: Address)`.
+
+---
 ### `remove_alert`
 
 Permanently removes an alert config. Only the original owner may call this.

--- a/docs/alert-registry.md
+++ b/docs/alert-registry.md
@@ -564,7 +564,7 @@ Returns the total number of alerts ever registered.
 
 ### `set_watcher_registry`
 
-Configures the `WatcherRegistry` contract address used for optional watcher-gating on read queries. Once set, `get_alerts_for_contract`, `get_alerts_by_owner`, and their paginated variants will cross-call `WatcherRegistry::is_watcher_authorized` before returning data. Admin only.
+Configures the `WatcherRegistry` contract address used for optional watcher-gating on read queries. Once set, `get_alerts_for_contract`, `get_alerts_by_owner`, and their paginated variants will cross-call `WatcherRegistry::is_watcher_authorized` before returning data. Any address configured here — including a zero/default `Address` — is treated as a real registry and will be cross-called; use `clear_watcher_registry` to disable gating. Admin only.
 
 **Requires auth:** `admin`
 
@@ -576,6 +576,24 @@ Configures the `WatcherRegistry` contract address used for optional watcher-gati
 | `watcher_registry` | `Address` | Address of the deployed `WatcherRegistry` contract |
 
 **Returns:** nothing
+
+---
+
+### `clear_watcher_registry`
+
+Clears the configured `WatcherRegistry` contract address, disabling watcher-gating on the read queries. After this call, `get_alerts_for_contract`, `get_alerts_by_owner`, and their paginated variants no longer cross-call `WatcherRegistry` and behave as if gating had never been configured. Call `set_watcher_registry` again to re-enable gating. Admin only.
+
+**Requires auth:** `admin`
+
+**Parameters**
+
+| Name | Type | Description |
+|---|---|---|
+| `admin` | `Address` | Current admin address |
+
+**Returns:** nothing
+
+**Errors:** Returns `ContractError::NotInitialized` if the contract has not been initialized; `ContractError::Unauthorized` if caller is not the admin.
 
 ---
 

--- a/docs/alert-registry.md
+++ b/docs/alert-registry.md
@@ -20,6 +20,18 @@ Contract that stores alert configurations on-chain, keyed by contract address.
 | `active` | `bool` | Whether the alert is active |
 | `pending_webhook_hash` | `Option<String>` | Pending webhook hash proposed via `propose_webhook`, not yet confirmed. `None` when no rotation is in progress. |
 
+### `AlertInput`
+
+Input record for [`batch_register_alert`](#batch_register_alert). Mirrors the arguments of `register_alert`.
+
+| Field | Type | Description |
+|---|---|---|
+| `owner` | `Address` | Address that will own and control this alert |
+| `target_contract` | `Address` | Contract address to watch |
+| `label` | `String` | Human-readable name for the alert |
+| `webhook_hash` | `String` | SHA-256 hex digest of the destination webhook URL |
+| `rules` | `Vec<String>` | Serialized rule descriptors |
+
 ---
 
 ## Webhook Hash Scheme
@@ -278,6 +290,43 @@ Transfers ownership of an alert to a new address. Updates the `owner` field of t
 **Errors:** Returns `ContractError::AlertNotFound` if ID does not exist; `ContractError::Unauthorized` if caller is not the owner.
 
 **Events:** Emits `(Symbol("alert"), Symbol("transfer"))` with data `(id: u64, old_owner: Address, new_owner: Address)`.
+
+---
+
+### `batch_register_alert`
+
+Registers multiple alert configs in a single call. Each input is validated and authorized exactly as `register_alert` would, and each successful registration emits the same `alert.register` event. Since Soroban invocations are atomic, if any input fails validation or authorization the entire batch — including any alerts already registered earlier in the same call — is rolled back.
+
+**Requires auth:** the `owner` of each input in `inputs`
+
+**Parameters**
+
+| Name | Type | Description |
+|---|---|---|
+| `inputs` | `Vec<AlertInput>` | Alert records to register |
+
+**Returns:** `Vec<u64>` — the new alerts' IDs, in the same order as `inputs`
+
+**Errors:** Returns the same errors as `register_alert` for the failing item.
+
+---
+
+### `batch_remove_alert`
+
+Removes multiple alert configs owned by `caller` in a single call. Each ID is validated and authorized exactly as `remove_alert` would, and each successful removal emits the same `alert.remove` event. Since Soroban invocations are atomic, if any ID does not exist or is not owned by `caller`, the entire batch is rolled back.
+
+**Requires auth:** `caller`
+
+**Parameters**
+
+| Name | Type | Description |
+|---|---|---|
+| `caller` | `Address` | Must own every alert in `config_ids` |
+| `config_ids` | `Vec<u64>` | IDs of the alerts to remove |
+
+**Returns:** nothing
+
+**Errors:** Returns `ContractError::AlertNotFound` if any ID does not exist; `ContractError::Unauthorized` if caller does not own every alert in `config_ids`.
 
 ---
 

--- a/docs/alert-registry.md
+++ b/docs/alert-registry.md
@@ -238,6 +238,28 @@ Permanently removes an alert config. Only the original owner may call this.
 
 ---
 
+### `transfer_alert_ownership`
+
+Transfers ownership of an alert to a new address. Updates the `owner` field of the alert config and migrates the alert ID from the old owner's `OwnerIndex` to the new owner's. Only the current owner may call this.
+
+**Requires auth:** `caller` (must match `owner` of the config)
+
+**Parameters**
+
+| Name | Type | Description |
+|---|---|---|
+| `caller` | `Address` | Must be the current alert owner |
+| `config_id` | `u64` | ID of the alert to transfer |
+| `new_owner` | `Address` | Address to become the new owner |
+
+**Returns:** nothing
+
+**Errors:** Returns `ContractError::AlertNotFound` if ID does not exist; `ContractError::Unauthorized` if caller is not the owner.
+
+**Events:** Emits `(Symbol("alert"), Symbol("transfer"))` with data `(id: u64, old_owner: Address, new_owner: Address)`.
+
+---
+
 ### `get_alert`
 
 Retrieves a single alert config by ID.


### PR DESCRIPTION
Closes #35 
Closes #38 
Closes #37 
Closes #44 

SUMMARY
 1. dacb9b2 — transfer_alert_ownership (#34): new owner-only mutator that reassigns AlertConfig.owner, migrates the alert ID between the old/new
     owner's OwnerIndex, and emits alert.transfer. Tests cover success, unauthorized rejection, not-found, and event emission.
  2. cf250be — deactivate_alert_by_admin (#36): admin-only soft moderation — flips active = false in place (record and indexes untouched, unlike
     remove_alert_by_admin), emits alert.admin_off. Tests cover success, unauthorized, not-found, event emission.
  3. 2088686 — batch_register_alert / batch_remove_alert (#37): new AlertInput struct plus two batch entry points that delegate per-item to the
     existing register_alert/remove_alert logic, preserving per-item validation and events; a failing item rolls back the whole batch (Soroban
     invocations are atomic). Tests cover batches of 1, 5, and 25, plus rollback-on-error cases for both functions.
  4. e23cdfd — clear_watcher_registry (#43): admin-only function that removes the WATCHREG instance key, restoring "gating disabled" behavior.
     Corrected the misleading "pass the zero address to disable gating" doc comment (zero address is never special-cased — it's cross-called like
     any other address) in both lib.rs and docs/alert-registry.md. Tests cover configure → gate → clear → ungated → reconfigure, plus
     unauthorized/uninitialized rejection.