### PR TITLE
Emit missing events from AlertRegistry (label, retarget, bulk deactivate, renew)

### DIFF
--- a/contracts/alert-registry/src/lib.rs
+++ b/contracts/alert-registry/src/lib.rs
@@ -855,6 +855,9 @@ impl AlertRegistry {
     ///
     /// # Panics
     /// Panics if `label` exceeds 128 bytes.
+    ///
+    /// # Events
+    /// Emits `(Symbol("alert"), Symbol("label"))` with data `(id: u64, caller: Address)`.
     pub fn update_label(
         env: Env,
         caller: Address,
@@ -895,6 +898,12 @@ impl AlertRegistry {
             DEFAULT_TTL,
             DEFAULT_TTL,
         );
+
+        env.events().publish(
+            (symbol_short!("alert"), symbol_short!("label")),
+            (config_id, caller),
+        );
+
         Ok(())
     }
 

--- a/contracts/alert-registry/src/lib.rs
+++ b/contracts/alert-registry/src/lib.rs
@@ -807,6 +807,9 @@ impl AlertRegistry {
     /// # Errors
     /// Returns [`ContractError::AlertNotFound`] if `config_id` does not exist.
     /// Returns [`ContractError::Unauthorized`] if `caller` is not the owner.
+    ///
+    /// # Events
+    /// Emits `(Symbol("alert"), Symbol("renew"))` with data `(id: u64, owner: Address)`.
     pub fn renew_alert_ttl(env: Env, caller: Address, config_id: u64) -> Result<(), ContractError> {
         caller.require_auth();
         Self::assert_not_paused(&env)?;
@@ -837,6 +840,12 @@ impl AlertRegistry {
             DEFAULT_TTL,
             DEFAULT_TTL,
         );
+
+        env.events().publish(
+            (symbol_short!("alert"), symbol_short!("renew")),
+            (config_id, caller),
+        );
+
         Ok(())
     }
 

--- a/contracts/alert-registry/src/lib.rs
+++ b/contracts/alert-registry/src/lib.rs
@@ -1359,6 +1359,11 @@ impl AlertRegistry {
     /// The number of alerts that were deactivated.
     /// # Panics
     /// Panics if the contract's stored state is malformed or missing.
+    ///
+    /// # Events
+    /// Emits `(Symbol("alert"), Symbol("bulk_off"))` with data
+    /// `(caller: Address, count: u32)` when at least one alert was deactivated.
+    /// No event is emitted if `count` is `0`.
     pub fn deactivate_all_alerts(env: Env, caller: Address) -> u32 {
         caller.require_auth();
         if Self::is_paused(env.clone()) {
@@ -1393,6 +1398,12 @@ impl AlertRegistry {
                     count += 1;
                 }
             }
+        }
+        if count > 0 {
+            env.events().publish(
+                (symbol_short!("alert"), symbol_short!("bulk_off")),
+                (caller, count),
+            );
         }
         count
     }

--- a/contracts/alert-registry/src/lib.rs
+++ b/contracts/alert-registry/src/lib.rs
@@ -1409,6 +1409,10 @@ impl AlertRegistry {
     /// # Errors
     /// Returns [`ContractError::AlertNotFound`] if `config_id` does not exist.
     /// Returns [`ContractError::Unauthorized`] if `caller` is not the alert owner.
+    ///
+    /// # Events
+    /// Emits `(Symbol("alert"), Symbol("retarget"))` with data
+    /// `(id: u64, old_target: Address, new_target: Address)`.
     pub fn update_target_contract(
         env: Env,
         caller: Address,
@@ -1440,6 +1444,11 @@ impl AlertRegistry {
         // Migrate the contract index
         Self::remove_from_contract_index(&env, &old_target, config_id);
         Self::push_contract_index(&env, &new_target, config_id)?;
+
+        env.events().publish(
+            (symbol_short!("alert"), symbol_short!("retarget")),
+            (config_id, old_target, new_target),
+        );
 
         Ok(())
     }

--- a/contracts/alert-registry/src/tests.rs
+++ b/contracts/alert-registry/src/tests.rs
@@ -1200,6 +1200,26 @@ fn test_update_target_contract_moves_indices() {
 }
 
 #[test]
+fn test_update_target_contract_emits_event() {
+    let (env, client) = setup();
+    let owner = Address::generate(&env);
+    let target_a = Address::generate(&env);
+    let target_b = Address::generate(&env);
+
+    let id = client.register_alert(
+        &owner,
+        &target_a,
+        &str(&env, "Target Alert"),
+        &hash64(&env),
+        &vec![&env],
+    );
+
+    client.update_target_contract(&owner, &id, &target_b);
+
+    assert!(!env.events().all().is_empty());
+}
+
+#[test]
 fn test_get_alert_active_states_and_counts() {
     let (env, client) = setup();
     let owner = Address::generate(&env);

--- a/contracts/alert-registry/src/tests.rs
+++ b/contracts/alert-registry/src/tests.rs
@@ -676,6 +676,26 @@ fn test_renew_alert_ttl_happy_path() {
     assert_eq!(after.created_at, before.created_at);
 }
 
+// renew_alert_ttl emits a renew event
+#[test]
+fn test_renew_alert_ttl_emits_event() {
+    let (env, client) = setup();
+    let owner = Address::generate(&env);
+    let target = Address::generate(&env);
+
+    let id = client.register_alert(
+        &owner,
+        &target,
+        &str(&env, "Alert"),
+        &hash64(&env),
+        &vec![&env],
+    );
+
+    client.renew_alert_ttl(&owner, &id);
+
+    assert!(!env.events().all().is_empty());
+}
+
 // renew_alert_ttl — unauthorized caller is rejected
 #[test]
 fn test_renew_alert_ttl_unauthorized() {

--- a/contracts/alert-registry/src/tests.rs
+++ b/contracts/alert-registry/src/tests.rs
@@ -1287,6 +1287,7 @@ fn test_deactivate_all_alerts_precise_behavior() {
     assert_eq!(client.get_active_alert_count(&owner2), 1);
 
     let count = client.deactivate_all_alerts(&owner1);
+    assert!(!env.events().all().is_empty());
     assert_eq!(count, 3);
     assert_eq!(client.get_alert_active(&Address::generate(&env), &id0), Some(false));
     assert_eq!(client.get_alert_active(&Address::generate(&env), &id1), Some(false));

--- a/contracts/alert-registry/src/tests.rs
+++ b/contracts/alert-registry/src/tests.rs
@@ -974,6 +974,26 @@ fn test_confirm_webhook_emits_event() {
     assert!(!env.events().all().is_empty());
 }
 
+// update_label emits a label event
+#[test]
+fn test_update_label_emits_event() {
+    let (env, client) = setup();
+    let owner = Address::generate(&env);
+    let target = Address::generate(&env);
+
+    let id = client.register_alert(
+        &owner,
+        &target,
+        &str(&env, "Alert"),
+        &hash64(&env),
+        &vec![&env],
+    );
+
+    client.update_label(&owner, &id, &str(&env, "New Label"));
+
+    assert!(!env.events().all().is_empty());
+}
+
 // pending_webhook_hash is None on fresh registration
 #[test]
 fn test_pending_webhook_hash_none_on_registration() {

--- a/docs/events.md
+++ b/docs/events.md
@@ -149,6 +149,25 @@ Emitted when an alert's watched contract is changed via `update_target_contract`
 
 ---
 
+### `alert.bulk_off`
+
+Emitted once per call to `deactivate_all_alerts` when at least one of the
+caller's alerts was deactivated. Carries the total affected count rather than
+one event per alert, keeping the bulk operation's footprint constant.
+
+| Field | Value |
+|---|---|
+| Topic 0 | `Symbol("alert")` |
+| Topic 1 | `Symbol("bulk_off")` |
+| Data | `(caller: Address, count: u32)` |
+
+> No event is emitted if `count` is `0` (e.g. the caller has no active alerts,
+> or the contract is paused).
+
+**Status:** ✅ implemented (`deactivate_all_alerts`)
+
+---
+
 ### `admin.init`
 
 Emitted when the admin role is first initialised.

--- a/docs/events.md
+++ b/docs/events.md
@@ -121,6 +121,20 @@ Emitted when an alert's TTL is extended via `bump_alert`.
 
 ---
 
+### `alert.label`
+
+Emitted when an alert's label is renamed via `update_label`.
+
+| Field | Value |
+|---|---|
+| Topic 0 | `Symbol("alert")` |
+| Topic 1 | `Symbol("label")` |
+| Data | `(id: u64, caller: Address)` |
+
+**Status:** ✅ implemented (`update_label`)
+
+---
+
 ### `admin.init`
 
 Emitted when the admin role is first initialised.

--- a/docs/events.md
+++ b/docs/events.md
@@ -168,6 +168,20 @@ one event per alert, keeping the bulk operation's footprint constant.
 
 ---
 
+### `alert.renew`
+
+Emitted when an alert's TTL is renewed via `renew_alert_ttl`.
+
+| Field | Value |
+|---|---|
+| Topic 0 | `Symbol("alert")` |
+| Topic 1 | `Symbol("renew")` |
+| Data | `(id: u64, owner: Address)` |
+
+**Status:** ✅ implemented (`renew_alert_ttl`)
+
+---
+
 ### `admin.init`
 
 Emitted when the admin role is first initialised.

--- a/docs/events.md
+++ b/docs/events.md
@@ -135,6 +135,20 @@ Emitted when an alert's label is renamed via `update_label`.
 
 ---
 
+### `alert.retarget`
+
+Emitted when an alert's watched contract is changed via `update_target_contract`.
+
+| Field | Value |
+|---|---|
+| Topic 0 | `Symbol("alert")` |
+| Topic 1 | `Symbol("retarget")` |
+| Data | `(id: u64, old_target: Address, new_target: Address)` |
+
+**Status:** ✅ implemented (`update_target_contract`)
+
+---
+
 ### `admin.init`
 
 Emitted when the admin role is first initialised.


### PR DESCRIPTION
## Summary
- Emit `alert.label` from `update_label` (id, caller)
- Emit `alert.retarget` from `update_target_contract` (id, old_target, new_target)
- Emit `alert.bulk_off` from `deactivate_all_alerts` (caller, count) — one event per call, skipped when count is 0
- Emit `alert.renew` from `renew_alert_ttl` (id, owner)
- Documented each new event in docs/events.md and added tests asserting emission

Closes #6
Closes #7
Closes #8
Closes #9