### PR TITLE
Emit events from update_alert, update_webhook, initialize, set_per_owner_alert_limit

### DIFF
--- a/contracts/alert-registry/src/lib.rs
+++ b/contracts/alert-registry/src/lib.rs
@@ -643,6 +643,11 @@ impl AlertRegistry {
             DEFAULT_TTL,
             DEFAULT_TTL,
         );
+
+        env.events().publish(
+            (symbol_short!("alert"), symbol_short!("update")),
+            (config_id, config.owner.clone(), active),
+        );
         Ok(())
     }
 

--- a/contracts/alert-registry/src/lib.rs
+++ b/contracts/alert-registry/src/lib.rs
@@ -700,6 +700,11 @@ impl AlertRegistry {
             DEFAULT_TTL,
             DEFAULT_TTL,
         );
+
+        env.events().publish(
+            (symbol_short!("alert"), symbol_short!("webhook")),
+            (config_id, caller),
+        );
         Ok(())
     }
 

--- a/contracts/alert-registry/src/lib.rs
+++ b/contracts/alert-registry/src/lib.rs
@@ -334,6 +334,11 @@ impl AlertRegistry {
         env.storage()
             .instance()
             .set(&symbol_short!("LIMIT"), &limit);
+
+        env.events().publish(
+            (symbol_short!("admin"), symbol_short!("limit")),
+            (admin, limit),
+        );
         Ok(())
     }
 

--- a/contracts/alert-registry/src/lib.rs
+++ b/contracts/alert-registry/src/lib.rs
@@ -203,6 +203,11 @@ impl AlertRegistry {
         env.storage()
             .instance()
             .set(&symbol_short!("ADMIN"), &admin);
+
+        env.events().publish(
+            (symbol_short!("admin"), symbol_short!("init")),
+            (admin,),
+        );
         Ok(())
     }
 

--- a/contracts/alert-registry/src/tests.rs
+++ b/contracts/alert-registry/src/tests.rs
@@ -190,6 +190,17 @@ fn test_admin_remove_any_alert() {
     assert!(client.get_alert(&owner, &id).is_none());
 }
 
+// initialize emits an admin.init event on first initialization
+#[test]
+fn test_initialize_emits_event() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin);
+
+    assert!(!env.events().all().is_empty());
+}
+
 #[test]
 #[should_panic(expected = "Error(Contract, #10)")]
 fn test_admin_set_per_owner_alert_limit() {

--- a/contracts/alert-registry/src/tests.rs
+++ b/contracts/alert-registry/src/tests.rs
@@ -201,6 +201,18 @@ fn test_initialize_emits_event() {
     assert!(!env.events().all().is_empty());
 }
 
+// set_per_owner_alert_limit emits an admin.limit event
+#[test]
+fn test_set_per_owner_alert_limit_emits_event() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    client.set_per_owner_alert_limit(&admin, &5u32);
+
+    assert!(!env.events().all().is_empty());
+}
+
 #[test]
 #[should_panic(expected = "Error(Contract, #10)")]
 fn test_admin_set_per_owner_alert_limit() {

--- a/contracts/alert-registry/src/tests.rs
+++ b/contracts/alert-registry/src/tests.rs
@@ -92,6 +92,26 @@ fn test_update_alert() {
     assert_eq!(cfg.rules.get(0).unwrap(), str(&env, "rule:mint"));
 }
 
+// update_alert emits an alert.update event
+#[test]
+fn test_update_alert_emits_event() {
+    let (env, client) = setup();
+    let owner = Address::generate(&env);
+    let target = Address::generate(&env);
+
+    let id = client.register_alert(
+        &owner,
+        &target,
+        &str(&env, "Alert"),
+        &hash64(&env),
+        &vec![&env, str(&env, "rule:transfer")],
+    );
+
+    client.update_alert(&owner, &id, &vec![&env, str(&env, "rule:mint")], &false);
+
+    assert!(!env.events().all().is_empty());
+}
+
 // 3. Happy path — remove alert
 #[test]
 fn test_remove_alert() {

--- a/contracts/alert-registry/src/tests.rs
+++ b/contracts/alert-registry/src/tests.rs
@@ -509,6 +509,26 @@ fn test_update_webhook() {
     );
 }
 
+// update_webhook emits an alert.webhook event
+#[test]
+fn test_update_webhook_emits_event() {
+    let (env, client) = setup();
+    let owner = Address::generate(&env);
+    let target = Address::generate(&env);
+
+    let id = client.register_alert(
+        &owner,
+        &target,
+        &str(&env, "A"),
+        &hash64c(&env, 'a'),
+        &vec![&env],
+    );
+
+    client.update_webhook(&owner, &id, &hash64c(&env, 'b'));
+
+    assert!(!env.events().all().is_empty());
+}
+
 // 11. update_webhook unauthorized
 #[test]
 fn test_update_webhook_unauthorized() {

--- a/docs/events.md
+++ b/docs/events.md
@@ -159,7 +159,7 @@ Emitted when the per-owner alert limit is changed.
 | Topic 1 | `Symbol("limit")` |
 | Data | `(admin: Address, limit: u32)` |
 
-**Status:** 🔲 planned (`set_per_owner_alert_limit`)
+**Status:** ✅ implemented (`set_per_owner_alert_limit`)
 
 ---
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -37,7 +37,7 @@ Emitted when an alert's rules or active flag are changed.
 | Topic 1 | `Symbol("update")` |
 | Data | `(id: u64, owner: Address, active: bool)` |
 
-**Status:** 🔲 planned (`update_alert`)
+**Status:** ✅ implemented (`update_alert`)
 
 ---
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -55,7 +55,7 @@ Emitted when an alert's webhook hash is rotated.
 > stored on-chain and can be read via `get_alert`.  Omitting it keeps the
 > event payload small and avoids redundancy.
 
-**Status:** 🔲 planned (`update_webhook`)
+**Status:** ✅ implemented (`update_webhook`)
 
 ---
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -131,7 +131,7 @@ Emitted when the admin role is first initialised.
 | Topic 1 | `Symbol("init")` |
 | Data | `(admin: Address)` |
 
-**Status:** 🔲 planned (`initialize`)
+**Status:** ✅ implemented (`initialize`)
 
 ---
 


### PR DESCRIPTION
Wires up the four AlertRegistry events already documented as \"planned\" in docs/events.md but never emitted on-chain.

- `alert.update` from `update_alert` — `(id, owner, active)`
- `alert.webhook` from `update_webhook` — `(id, caller)`
- `admin.init` from `initialize` — `(admin,)`
- `admin.limit` from `set_per_owner_alert_limit` — `(admin, limit)`

Each change follows the existing `(topic1, topic2)` + data-payload convention used elsewhere in the contract, adds a test asserting the event is emitted, and flips the corresponding docs/events.md status from planned to implemented.

Closes #2
Closes #3
Closes #4
Closes #5