### PR TITLE
docs: fix TTL claims and alert-registry function signatures

### DIFF
--- a/docs/alert-registry.md
+++ b/docs/alert-registry.md
@@ -374,13 +374,16 @@ If a `WatcherRegistry` is configured (via `set_watcher_registry`), `querier` mus
 
 Returns all alert configs registered for a given target contract, including both active and inactive entries. Use [`get_active_alerts_for_contract`](#get_active_alerts_for_contract) to filter to active-only.
 
+If a `WatcherRegistry` is configured (via `set_watcher_registry`), `querier` must be a registered watcher or the call returns `ContractError::NotAWatcher`.
+
 **Parameters**
 
 | Name | Type | Description |
 |---|---|---|
+| `querier` | `Address` | Address performing the query (checked against watcher registry if configured) |
 | `target_contract` | `Address` | Contract address to query |
 
-**Returns:** `Vec<AlertConfig>` — may be empty.
+**Returns:** `Result<Vec<AlertConfig>, ContractError>` — `Ok(vec)` on success, may be empty.
 
 ---
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -38,7 +38,7 @@ Source: `contracts/alert-registry/src/lib.rs`
 
 ### TTL Behavior
 
-All persistent key variants (`Alert`, `AlertActive`, `OwnerIndex`, `OwnerActiveCount`, `ContractIndex`) are extended by **100 ledgers** (≈ 8 minutes at 5 s/ledger) on every write that touches them.
+All persistent key variants (`Alert`, `AlertActive`, `OwnerIndex`, `OwnerActiveCount`, `ContractIndex`) are extended by `DEFAULT_TTL` (**17,280 ledgers**, ≈ 24 hours at 5 s/ledger) on every write that touches them. `bump_alert` can extend an alert's TTL further, up to `MAX_TTL` (535,680 ledgers, ≈ 31 days).
 
 | Function | Keys Extended |
 |---|---|
@@ -54,7 +54,7 @@ Read-only functions (`get_alert`, `get_alerts_for_contract`, `get_alerts_by_owne
 
 The `NEXT_ID` instance key has no explicit TTL management — its lifetime is tied to the contract instance itself.
 
-> See [docs/ttl.md](ttl.md) for implications of the 100-ledger setting and recommended production values.
+> See [docs/ttl.md](ttl.md) for implications of the DEFAULT_TTL setting and recommended production values.
 
 ---
 
@@ -82,6 +82,6 @@ There are no persistent storage entries in WatcherRegistry.
 
 | Contract | Tier | Keys | TTL Managed By |
 |---|---|---|---|
-| AlertRegistry | Persistent | `Alert`, `OwnerIndex`, `OwnerActiveCount`, `ContractIndex` | Contract (`extend_ttl`, 100 ledgers) |
+| AlertRegistry | Persistent | `Alert`, `OwnerIndex`, `OwnerActiveCount`, `ContractIndex` | Contract (`extend_ttl`, DEFAULT_TTL = 17,280 ledgers) |
 | AlertRegistry | Instance | `NEXT_ID` | Network |
 | WatcherRegistry | Instance | `Admins`, `Watchers`, `W_CNT` | Network |

--- a/docs/ttl.md
+++ b/docs/ttl.md
@@ -103,7 +103,7 @@ Read-only functions (`get_alert`, `get_alerts_for_contract`, `get_alerts_by_owne
 
 ## Implications
 
-- **Inactive alerts expire quickly.** An alert that is registered but never updated will be archived after ~8 minutes.
+- **Inactive alerts expire eventually.** An alert that is registered but never updated will be archived after `DEFAULT_TTL` (17,280 ledgers, ~24 hours).
 - **Watchers must keep alerts alive.** Any off-chain service relying on alert data should periodically call `update_alert` (or a dedicated bump function) to prevent expiry.
 - **Archived entries are not deleted.** They can be restored via `RestoreFootprintOp`, but this requires paying a fee and is not currently automated.
 


### PR DESCRIPTION
Doc-accuracy fixes for TTL documentation and alert-registry function docs.

- Closes #14
- Closes #15
- Closes #16
- Closes #17

## Summary

- **#14**: `docs/ttl.md` had a leftover "archived after ~8 minutes" claim contradicting the doc's own `DEFAULT_TTL = 17,280 ledgers (~24h)`. Fixed to reference `DEFAULT_TTL`.
- **#15**: `docs/storage.md`'s TTL Behavior section still said entries are extended by "100 ledgers (≈8 minutes)", predating `DEFAULT_TTL`. Updated to `DEFAULT_TTL` (17,280 ledgers, ~24h) and noted `MAX_TTL` for `bump_alert`; also fixed two other stale "100-ledger" references in the same doc.
- **#16**: `get_alerts_for_contract`'s documented signature omitted the required `querier: Address` parameter and the `Result<Vec<AlertConfig>, ContractError>` return type present on the real function. Updated the doc to match, including the watcher-gating note.
- **#17**: Skipped — verified against current `main` that `get_active_alerts_for_contract` already takes `querier` and is already gated via `assert_watcher_if_configured` (returning `Result`), and the existing doc text already matches that behavior correctly. The bypass this issue described appears already resolved by the code fix in #42. Left a comment on the issue explaining this.

## Test plan
- Documentation-only changes; no code touched. No build/test run per task instructions.