### PR TITLE
Alert-registry: watcher-registry event, TTL index refresh fixes, TTL docs

### DIFF
--- a/contracts/alert-registry/src/lib.rs
+++ b/contracts/alert-registry/src/lib.rs
@@ -1406,9 +1406,21 @@ impl AlertRegistry {
                         DEFAULT_TTL,
                         DEFAULT_TTL,
                     );
+                    env.storage().persistent().extend_ttl(
+                        &DataKey::ContractIndex(cfg.target_contract.clone()),
+                        DEFAULT_TTL,
+                        DEFAULT_TTL,
+                    );
                     count += 1;
                 }
             }
+        }
+        if count > 0 {
+            env.storage().persistent().extend_ttl(
+                &DataKey::OwnerIndex(caller.clone()),
+                DEFAULT_TTL,
+                DEFAULT_TTL,
+            );
         }
         count
     }

--- a/contracts/alert-registry/src/lib.rs
+++ b/contracts/alert-registry/src/lib.rs
@@ -451,6 +451,11 @@ impl AlertRegistry {
         env.storage()
             .instance()
             .set(&symbol_short!("WATCHREG"), &watcher_registry);
+
+        env.events().publish(
+            (symbol_short!("admin"), symbol_short!("watchreg")),
+            (admin, watcher_registry),
+        );
         Ok(())
     }
 

--- a/contracts/alert-registry/src/lib.rs
+++ b/contracts/alert-registry/src/lib.rs
@@ -742,6 +742,16 @@ impl AlertRegistry {
         env.storage()
             .persistent()
             .extend_ttl(&DataKey::Alert(config_id), DEFAULT_TTL, DEFAULT_TTL);
+        env.storage().persistent().extend_ttl(
+            &DataKey::OwnerIndex(config.owner.clone()),
+            DEFAULT_TTL,
+            DEFAULT_TTL,
+        );
+        env.storage().persistent().extend_ttl(
+            &DataKey::ContractIndex(config.target_contract.clone()),
+            DEFAULT_TTL,
+            DEFAULT_TTL,
+        );
 
         env.events().publish(
             (symbol_short!("alert"), symbol_short!("wh_prop")),
@@ -791,6 +801,16 @@ impl AlertRegistry {
         env.storage()
             .persistent()
             .extend_ttl(&DataKey::Alert(config_id), DEFAULT_TTL, DEFAULT_TTL);
+        env.storage().persistent().extend_ttl(
+            &DataKey::OwnerIndex(config.owner.clone()),
+            DEFAULT_TTL,
+            DEFAULT_TTL,
+        );
+        env.storage().persistent().extend_ttl(
+            &DataKey::ContractIndex(config.target_contract.clone()),
+            DEFAULT_TTL,
+            DEFAULT_TTL,
+        );
 
         env.events().publish(
             (symbol_short!("alert"), symbol_short!("wh_conf")),

--- a/contracts/alert-registry/src/tests.rs
+++ b/contracts/alert-registry/src/tests.rs
@@ -1037,6 +1037,26 @@ fn test_ten_alerts_same_owner_same_contract() {
     );
 }
 
+// set_watcher_registry emits an admin.watchreg event
+#[test]
+fn test_set_watcher_registry_emits_event() {
+    use watcher_registry::{WatcherRegistry, WatcherRegistryClient};
+
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let registry_id = env.register(WatcherRegistry, ());
+    let registry_client = WatcherRegistryClient::new(&env, &registry_id);
+    registry_client.initialize(&admin);
+    registry_client.register_watcher(&admin, &admin);
+
+    client.set_watcher_registry(&admin, &registry_id);
+
+    assert!(!env.events().all().is_empty());
+    assert_eq!(client.get_watcher_registry(), Some(registry_id));
+}
+
 #[test]
 fn test_is_watcher_gating_enabled_default_false() {
     let (_env, client) = setup();

--- a/contracts/alert-registry/src/tests.rs
+++ b/contracts/alert-registry/src/tests.rs
@@ -1037,6 +1037,69 @@ fn test_ten_alerts_same_owner_same_contract() {
     );
 }
 
+// propose_webhook/confirm_webhook must refresh OwnerIndex/ContractIndex TTLs,
+// not just the Alert(id) key, so an alert that is only ever webhook-rotated
+// stays reachable via get_alerts_by_owner / get_alerts_for_contract.
+#[test]
+fn test_webhook_rotation_refreshes_owner_and_contract_index_ttl() {
+    use crate::DataKey;
+    use soroban_sdk::testutils::storage::Persistent;
+
+    let (env, client) = setup();
+    let owner = Address::generate(&env);
+    let target = Address::generate(&env);
+
+    let id = client.register_alert(
+        &owner,
+        &target,
+        &str(&env, "Alert"),
+        &hash64(&env),
+        &vec![&env],
+    );
+
+    // Let the owner/contract index TTLs run down close to expiry while the
+    // alert is only rotated via propose_webhook/confirm_webhook.
+    env.as_contract(&client.address, || {
+        env.storage().persistent().extend_ttl(
+            &DataKey::OwnerIndex(owner.clone()),
+            0,
+            0,
+        );
+        env.storage().persistent().extend_ttl(
+            &DataKey::ContractIndex(target.clone()),
+            0,
+            0,
+        );
+    });
+
+    client.propose_webhook(&owner, &id, &hash64c(&env, 'z'));
+    client.confirm_webhook(&owner, &id);
+
+    let owner_ttl = env.as_contract(&client.address, || {
+        env.storage()
+            .persistent()
+            .get_ttl(&DataKey::OwnerIndex(owner.clone()))
+    });
+    let contract_ttl = env.as_contract(&client.address, || {
+        env.storage()
+            .persistent()
+            .get_ttl(&DataKey::ContractIndex(target.clone()))
+    });
+
+    assert!(
+        owner_ttl > 0,
+        "OwnerIndex TTL must be refreshed by webhook rotation"
+    );
+    assert!(
+        contract_ttl > 0,
+        "ContractIndex TTL must be refreshed by webhook rotation"
+    );
+
+    // The alert must still be reachable via both indexes.
+    assert_eq!(client.get_alerts_by_owner(&owner, &owner).len(), 1);
+    assert_eq!(client.get_alerts_for_contract(&owner, &target).len(), 1);
+}
+
 // set_watcher_registry emits an admin.watchreg event
 #[test]
 fn test_set_watcher_registry_emits_event() {

--- a/contracts/alert-registry/src/tests.rs
+++ b/contracts/alert-registry/src/tests.rs
@@ -1037,6 +1037,58 @@ fn test_ten_alerts_same_owner_same_contract() {
     );
 }
 
+// deactivate_all_alerts must refresh OwnerIndex/ContractIndex TTLs, not just
+// Alert(id)/AlertActive(id), even though it iterates the owner's entire index.
+#[test]
+fn test_deactivate_all_alerts_refreshes_owner_and_contract_index_ttl() {
+    use crate::DataKey;
+    use soroban_sdk::testutils::storage::Persistent;
+
+    let (env, client) = setup();
+    let owner = Address::generate(&env);
+    let target = Address::generate(&env);
+
+    client.register_alert(
+        &owner,
+        &target,
+        &str(&env, "Alert"),
+        &hash64(&env),
+        &vec![&env],
+    );
+
+    env.as_contract(&client.address, || {
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::OwnerIndex(owner.clone()), 0, 0);
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::ContractIndex(target.clone()), 0, 0);
+    });
+
+    let count = client.deactivate_all_alerts(&owner);
+    assert_eq!(count, 1);
+
+    let owner_ttl = env.as_contract(&client.address, || {
+        env.storage()
+            .persistent()
+            .get_ttl(&DataKey::OwnerIndex(owner.clone()))
+    });
+    let contract_ttl = env.as_contract(&client.address, || {
+        env.storage()
+            .persistent()
+            .get_ttl(&DataKey::ContractIndex(target.clone()))
+    });
+
+    assert!(
+        owner_ttl > 0,
+        "OwnerIndex TTL must be refreshed by deactivate_all_alerts"
+    );
+    assert!(
+        contract_ttl > 0,
+        "ContractIndex TTL must be refreshed by deactivate_all_alerts"
+    );
+}
+
 // propose_webhook/confirm_webhook must refresh OwnerIndex/ContractIndex TTLs,
 // not just the Alert(id) key, so an alert that is only ever webhook-rotated
 // stays reachable via get_alerts_by_owner / get_alerts_for_contract.

--- a/docs/events.md
+++ b/docs/events.md
@@ -163,6 +163,21 @@ Emitted when the per-owner alert limit is changed.
 
 ---
 
+### `admin.watchreg`
+
+Emitted when the `WatcherRegistry` contract address is configured, gating the
+read-side queries behind watcher authorization.
+
+| Field | Value |
+|---|---|
+| Topic 0 | `Symbol("admin")` |
+| Topic 1 | `Symbol("watchreg")` |
+| Data | `(admin: Address, watcher_registry: Address)` |
+
+**Status:** ✅ implemented (`set_watcher_registry`)
+
+---
+
 ## WatcherRegistry
 
 ### `watcher.register`

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -45,8 +45,8 @@ All persistent key variants (`Alert`, `AlertActive`, `OwnerIndex`, `OwnerActiveC
 | `register_alert` | `Alert(id)`, `AlertActive(id)`, `OwnerIndex(owner)`, `OwnerActiveCount(owner)`, `ContractIndex(target)` |
 | `update_alert` | `Alert(id)`, `AlertActive(id)` |
 | `update_webhook` | `Alert(id)` |
-| `propose_webhook` | `Alert(id)` |
-| `confirm_webhook` | `Alert(id)` |
+| `propose_webhook` | `Alert(id)`, `OwnerIndex(owner)`, `ContractIndex(target)` |
+| `confirm_webhook` | `Alert(id)`, `OwnerIndex(owner)`, `ContractIndex(target)` |
 | `renew_alert_ttl` | `Alert(id)`, `OwnerIndex(owner)`, `ContractIndex(target)` — data unchanged |
 | `remove_alert` | `Alert(id)`, `AlertActive(id)` deleted; `OwnerIndex(owner)`, `OwnerActiveCount(owner)`, `ContractIndex(target)` updated and TTL-extended |
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -48,6 +48,7 @@ All persistent key variants (`Alert`, `AlertActive`, `OwnerIndex`, `OwnerActiveC
 | `propose_webhook` | `Alert(id)`, `OwnerIndex(owner)`, `ContractIndex(target)` |
 | `confirm_webhook` | `Alert(id)`, `OwnerIndex(owner)`, `ContractIndex(target)` |
 | `renew_alert_ttl` | `Alert(id)`, `OwnerIndex(owner)`, `ContractIndex(target)` — data unchanged |
+| `deactivate_all_alerts` | `Alert(id)`, `AlertActive(id)` for each deactivated alert; `ContractIndex(target)` for each touched contract; `OwnerIndex(caller)` once, if at least one alert was deactivated |
 | `remove_alert` | `Alert(id)`, `AlertActive(id)` deleted; `OwnerIndex(owner)`, `OwnerActiveCount(owner)`, `ContractIndex(target)` updated and TTL-extended |
 
 Read-only functions (`get_alert`, `get_alerts_for_contract`, `get_alerts_by_owner`, paginated variants, `get_alert_count`) do **not** extend any TTL.

--- a/docs/ttl.md
+++ b/docs/ttl.md
@@ -97,7 +97,12 @@ The TTL is extended on every mutating call that touches the entry:
 | `update_label`        | `Alert(id)`, `OwnerIndex`, `ContractIndex` |
 | `update_target_contract` | `Alert(id)`, old and new `ContractIndex` |
 | `bump_alert`          | `Alert(id)`, `AlertActive(id)`, `OwnerIndex`, `ContractIndex` |
+| `renew_alert_ttl`     | `Alert(id)`, `OwnerIndex`, `ContractIndex` — data unchanged |
+| `propose_webhook`     | `Alert(id)`, `OwnerIndex`, `ContractIndex` |
+| `confirm_webhook`     | `Alert(id)`, `OwnerIndex`, `ContractIndex` |
+| `deactivate_all_alerts` | `Alert(id)`, `AlertActive(id)` for each deactivated alert; `ContractIndex` for each touched contract; `OwnerIndex` once, if at least one alert was deactivated |
 | `remove_alert`        | Entry is deleted (no TTL needed) |
+| `remove_alert_by_admin` | Entry is deleted (no TTL needed) |
 
 Read-only functions (`get_alert`, `get_alerts_for_contract`, `get_alerts_by_owner`) do **not** extend the TTL.
 


### PR DESCRIPTION
## Summary
- Emit an `admin.watchreg` event from `set_watcher_registry`, with a regression test and docs/events.md entry.
- Fix `propose_webhook`/`confirm_webhook` to also extend `OwnerIndex`/`ContractIndex` TTLs (previously only `Alert(id)`), matching `update_alert`/`update_webhook`/`update_label`.
- Fix `deactivate_all_alerts` to extend `ContractIndex` per touched contract and `OwnerIndex` once, instead of only `Alert(id)`/`AlertActive(id)`.
- Fill in the missing rows (`renew_alert_ttl`, `propose_webhook`, `confirm_webhook`, `deactivate_all_alerts`, `remove_alert_by_admin`) in `docs/ttl.md`'s "When Does the TTL Reset" table.

Closes #10
Closes #11
Closes #12
Closes #13

## Test plan
- [ ] `cargo test -p alert-registry` (not run in this environment per task constraints; new tests added: `test_set_watcher_registry_emits_event`, `test_webhook_rotation_refreshes_owner_and_contract_index_ttl`, `test_deactivate_all_alerts_refreshes_owner_and_contract_index_ttl`)