### PR TITLE
fix(alert-registry): count only active alerts in get_active_alert_count

### DIFF
--- a/contracts/alert-registry/src/lib.rs
+++ b/contracts/alert-registry/src/lib.rs
@@ -50,8 +50,8 @@ pub enum DataKey {
     OwnerIndex(Address),
     /// Stores the number of currently live (non-removed) alerts owned by a
     /// given address, maintained incrementally alongside [`DataKey::OwnerIndex`]
-    /// so [`AlertRegistry::get_active_alert_count`] never has to rescan the
-    /// owner's full index.
+    /// so [`AlertRegistry::get_non_removed_alert_count`] never has to rescan
+    /// the owner's full index.
     OwnerActiveCount(Address),
     /// Stores the list of alert IDs watching a given contract address.
     ContractIndex(Address),
@@ -1586,8 +1586,10 @@ impl AlertRegistry {
     /// Get the total number of alerts ever registered.
     ///
     /// This is a **monotonic counter** — it only increases and is never
-    /// decremented when alerts are removed. Use [`get_active_alert_count`]
-    /// if you need the number of currently live alerts for a given owner.
+    /// decremented when alerts are removed. Use [`get_non_removed_alert_count`]
+    /// if you need the number of currently live (non-removed) alerts for a
+    /// given owner, or [`get_active_alert_count`] for the number that are
+    /// still active.
     #[must_use]
     pub fn get_alert_count(env: Env) -> u64 {
         env.storage()
@@ -1596,17 +1598,47 @@ impl AlertRegistry {
             .unwrap_or(0u64)
     }
 
-    /// Get the number of currently active (non-removed) alerts owned by `owner`.
+    /// Get the number of currently active alerts owned by `owner`.
     ///
     /// Unlike [`get_alert_count`], this reflects removals and only counts
-    /// alerts whose storage entries are still live.
+    /// alerts with `active == true` — deactivated-but-not-removed alerts are
+    /// excluded, so the result matches the `active` flag of the alerts
+    /// returned by [`Self::get_alerts_by_owner`].
+    ///
+    /// Scans the owner's [`DataKey::OwnerIndex`] and reads the cheap
+    /// [`DataKey::AlertActive`] flag for each entry, so it reflects both
+    /// removals and deactivations. If you only need the number of live
+    /// (non-removed) alerts regardless of the `active` flag, use
+    /// [`Self::get_non_removed_alert_count`], which is an O(1) lookup.
+    #[must_use]
+    pub fn get_active_alert_count(env: Env, owner: Address) -> u32 {
+        let ids = Self::owner_index(&env, &owner);
+        let mut count: u32 = 0;
+        for i in 0..ids.len() {
+            let id = ids.get(i).unwrap();
+            if env
+                .storage()
+                .persistent()
+                .get::<DataKey, bool>(&DataKey::AlertActive(id))
+                == Some(true)
+            {
+                count += 1;
+            }
+        }
+        count
+    }
+
+    /// Get the number of currently live (non-removed) alerts owned by `owner`.
+    ///
+    /// Unlike [`Self::get_active_alert_count`], this does **not** filter by
+    /// the `active` flag: deactivated-but-not-removed alerts still count.
     ///
     /// Backed by a running counter maintained incrementally by
     /// [`Self::push_owner_index`]/[`Self::remove_from_owner_index`], so this
     /// is an O(1) lookup regardless of how many alerts `owner` has ever
-    /// registered — it no longer rescans the owner's index on every call.
+    /// registered — it never rescans the owner's index.
     #[must_use]
-    pub fn get_active_alert_count(env: Env, owner: Address) -> u32 {
+    pub fn get_non_removed_alert_count(env: Env, owner: Address) -> u32 {
         Self::owner_active_count(&env, &owner)
     }
 
@@ -1686,7 +1718,7 @@ impl AlertRegistry {
 
     fn assert_per_owner_limit(env: &Env, owner: &Address) -> Result<(), ContractError> {
         let limit = Self::get_per_owner_alert_limit(env.clone());
-        if limit > 0 && Self::get_active_alert_count(env.clone(), owner.clone()) >= limit {
+        if limit > 0 && Self::get_non_removed_alert_count(env.clone(), owner.clone()) >= limit {
             return Err(ContractError::OwnerAlertLimitExceeded);
         }
         Ok(())
@@ -3950,11 +3982,11 @@ mod tests {
         );
     }
 
-    /// `get_active_alert_count` is O(1) regardless of how many alerts an
+    /// `get_non_removed_alert_count` is O(1) regardless of how many alerts an
     /// owner has ever registered — it reads a maintained counter instead of
     /// rescanning `OwnerIndex` (#39).
     #[test]
-    fn test_get_active_alert_count_instruction_cost_is_constant() {
+    fn test_get_non_removed_alert_count_instruction_cost_is_constant() {
         const N: u32 = 200;
 
         let (env, client) = setup();
@@ -3968,16 +4000,16 @@ mod tests {
         }
 
         let before = env.cost_estimate().budget().cpu_instruction_cost();
-        let count = client.get_active_alert_count(&owner);
+        let count = client.get_non_removed_alert_count(&owner);
         let after = env.cost_estimate().budget().cpu_instruction_cost();
         let cost = after.saturating_sub(before);
 
         assert_eq!(count, N);
         // An O(n) rescan at N=200 would cost far more than a single storage
-        // read; this bound would fail under the old scan-based implementation.
+        // read; this bound would fail under a scan-based implementation.
         assert!(
             cost < 200_000,
-            "get_active_alert_count cost {cost} at N={N} looks O(n), not O(1)"
+            "get_non_removed_alert_count cost {cost} at N={N} looks O(n), not O(1)"
         );
     }
 

--- a/contracts/alert-registry/src/proptests.rs
+++ b/contracts/alert-registry/src/proptests.rs
@@ -652,9 +652,18 @@ fn run_state_machine(actions: Vec<AlertAction>) {
         for (i, owner) in owners.iter().take(3).enumerate() {
             let expected_active_count = model_alerts
                 .values()
-                .filter(|a| !a.removed && a.owner_idx == i)
+                .filter(|a| !a.removed && a.owner_idx == i && a.active)
                 .count() as u32;
             assert_eq!(client.get_active_alert_count(owner), expected_active_count);
+
+            let expected_non_removed_count = model_alerts
+                .values()
+                .filter(|a| !a.removed && a.owner_idx == i)
+                .count() as u32;
+            assert_eq!(
+                client.get_non_removed_alert_count(owner),
+                expected_non_removed_count
+            );
 
             let querier = Address::generate(&env);
             let on_chain_owner_alerts = client.get_alerts_by_owner(&querier, owner);

--- a/contracts/alert-registry/src/tests.rs
+++ b/contracts/alert-registry/src/tests.rs
@@ -483,6 +483,47 @@ fn test_get_active_alert_count() {
     assert_eq!(client.get_active_alert_count(&owner), 1);
 }
 
+// get_active_alert_count filters out deactivated-but-not-removed alerts,
+// while get_non_removed_alert_count counts every live alert regardless of
+// the active flag.
+#[test]
+fn test_get_active_alert_count_excludes_deactivated() {
+    let (env, client) = setup();
+    let owner = Address::generate(&env);
+    let target = Address::generate(&env);
+
+    let id1 = client.register_alert(&owner, &target, &str(&env, "A"), &hash64(&env), &vec![&env]);
+    let id2 = client.register_alert(&owner, &target, &str(&env, "B"), &hash64(&env), &vec![&env]);
+    let id3 = client.register_alert(&owner, &target, &str(&env, "C"), &hash64(&env), &vec![&env]);
+
+    assert_eq!(client.get_active_alert_count(&owner), 3);
+    assert_eq!(client.get_non_removed_alert_count(&owner), 3);
+
+    // Deactivate alert 2 — it is no longer active but still lives in storage.
+    client.update_alert(&owner, &id2, &vec![&env], &false);
+    assert_eq!(client.get_active_alert_count(&owner), 2);
+    assert_eq!(client.get_non_removed_alert_count(&owner), 3);
+
+    // Reactivating brings it back into the active count.
+    client.update_alert(&owner, &id2, &vec![&env], &true);
+    assert_eq!(client.get_active_alert_count(&owner), 3);
+    assert_eq!(client.get_non_removed_alert_count(&owner), 3);
+
+    // Deactivate again, then remove. The alert was inactive when removed, so
+    // the active count is unaffected while the non-removed count drops.
+    client.update_alert(&owner, &id2, &vec![&env], &false);
+    client.remove_alert(&owner, &id2);
+    assert_eq!(client.get_active_alert_count(&owner), 2);
+    assert_eq!(client.get_non_removed_alert_count(&owner), 2);
+
+    // Removing an active alert drops both counts.
+    client.remove_alert(&owner, &id1);
+    assert_eq!(client.get_active_alert_count(&owner), 1);
+    assert_eq!(client.get_non_removed_alert_count(&owner), 1);
+
+    let _ = id3;
+}
+
 // 10. update_webhook changes the hash
 #[test]
 fn test_update_webhook() {

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -15,7 +15,7 @@ Source: `contracts/alert-registry/src/lib.rs`
 | `DataKey::Alert(id: u64)` | Persistent | `AlertConfig` | A single alert configuration, keyed by its numeric ID |
 | `DataKey::AlertActive(id: u64)` | Persistent | `bool` | The `active` flag stored separately so it can be read without deserializing the full `AlertConfig` (see `get_alert_active`) |
 | `DataKey::OwnerIndex(addr: Address)` | Persistent | `Vec<u64>` | List of alert IDs owned by a given address |
-| `DataKey::OwnerActiveCount(addr: Address)` | Persistent | `u32` | Running count of currently live (non-removed) alerts owned by `addr`, maintained incrementally alongside `OwnerIndex` so `get_active_alert_count` is O(1) instead of rescanning the index |
+| `DataKey::OwnerActiveCount(addr: Address)` | Persistent | `u32` | Running count of currently live (non-removed) alerts owned by `addr`, maintained incrementally alongside `OwnerIndex` so `get_non_removed_alert_count` is O(1) instead of rescanning the index. `get_active_alert_count` instead scans `OwnerIndex` and filters by the `AlertActive` flag, so deactivated-but-not-removed alerts are excluded |
 | `DataKey::ContractIndex(addr: Address)` | Persistent | `Vec<u64>` | List of alert IDs watching a given contract address |
 | `symbol_short!("NEXT_ID")` | Instance | `u64` | Monotonic counter used to generate unique alert IDs |
 | `symbol_short!("ADMIN")` | Instance | `Address` | Optional admin address that may remove alerts and set owner limits |


### PR DESCRIPTION
Closes #19
Closes #20
Closes #21
Closes #22

## Description

`get_active_alert_count` claims to return "the number of currently active (non-removed) alerts", but it was backed by the incremental `OwnerActiveCount` counter, which is only decremented on removal — never when the `active` flag flips. A fully deactivated-but-not-removed alert (via `update_alert(active = false)`, `deactivate_alert_by_admin`, or `deactivate_all_alerts`) still counted, making the function's output misleading.

### Changes
- `get_active_alert_count` now scans the owner's `OwnerIndex` and counts only alerts whose `AlertActive` flag is `true`, so deactivated alerts are excluded (expired/removed entries naturally drop out too).
- Added `get_non_removed_alert_count` — the renamed, counter-backed O(1) function preserving the previous non-filtered semantics. `assert_per_owner_limit` continues to use it, so per-owner limit enforcement and its O(1) registration cost are unchanged (deactivated records still occupy storage).
- Updated doc comments and `docs/storage.md`.

## Related Issue
- None linked; surfaced as a bug report against the function's documented contract.

## Type of change
- Bugfix

## Checklist
- [x] My code follows the repository style
- [x] I have added relevant tests (unit / integration)
- [x] I have updated or added documentation if necessary
- [ ] All CI checks pass

## Testing notes
- New unit test `test_get_active_alert_count_excludes_deactivated` covers deactivate / reactivate / removal of inactive and active alerts, asserting both counts.
- The proptest invariant now asserts `get_active_alert_count` equals the model's active count and `get_non_removed_alert_count` equals its non-removed count.
- The O(1) load test was renamed to `test_get_non_removed_alert_count_instruction_cost_is_constant`.
- Not run locally (no Rust toolchain in the dev environment); CI runs `cargo test --workspace --locked`, `cargo clippy`, and `cargo fmt --check`.

## Release notes / changelog
- `get_active_alert_count` now reflects deactivations; `get_non_removed_alert_count` added for the previous live-count semantics.