### PR TITLE
Reject duplicate rule descriptors in validate_rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,10 @@ The workspace did not compile and the test suite had never run. Both are now gre
 - **`update_alert` silently discarded rule validation.** It called
   `validate_rules` and dropped the returned `Result`, so an alert could be
   updated with rule descriptors that `register_alert` rejects. Now propagated.
+- **`validate_rules` accepted duplicate rule descriptors.** `["rule:transfer",
+  "rule:transfer"]` was stored silently, wasting storage and skewing
+  rule-count-based limits. Duplicates are now rejected with
+  `ContractError::DuplicateRule` in both `register_alert` and `update_alert`.
 - **`update_webhook` accepted webhook hashes of any length**, while
   `register_alert` required exactly 64 characters. Both now enforce the same rule.
 - **`replace_watcher` could drop the replacement watcher.** Corrected so the new

--- a/contracts/alert-registry/src/lib.rs
+++ b/contracts/alert-registry/src/lib.rs
@@ -92,6 +92,9 @@ pub enum ContractError {
     InvalidWatcherRegistry = 13,
     /// Returned when a state-mutating call is made while the contract is paused.
     Paused = 13,
+    /// Returned by `validate_rules` when the same rule descriptor appears more
+    /// than once in an alert's rule list.
+    DuplicateRule = 15,
 }
 
 // ── Data types ───────────────────────────────────────────────────────────────
@@ -531,6 +534,7 @@ impl AlertRegistry {
     /// Returns [`ContractError::GlobalAlertLimitExceeded`] if the registry is at the configured global alert-count ceiling.
     /// Returns [`ContractError::TooManyRules`] if `rules` exceeds the 50-rule maximum.
     /// Returns [`ContractError::InvalidRuleDescriptor`] if a rule is not a recognised descriptor.
+    /// Returns [`ContractError::DuplicateRule`] if the same rule descriptor appears more than once.
     pub fn register_alert(
         env: Env,
         owner: Address,
@@ -600,6 +604,7 @@ impl AlertRegistry {
     /// Returns [`ContractError::Unauthorized`] if the caller is not authorized for this operation.
     /// Returns [`ContractError::TooManyRules`] if `rules` exceeds the 50-rule maximum.
     /// Returns [`ContractError::InvalidRuleDescriptor`] if a rule is not a recognised descriptor.
+    /// Returns [`ContractError::DuplicateRule`] if the same rule descriptor appears more than once.
     pub fn update_alert(
         env: Env,
         caller: Address,
@@ -1944,19 +1949,38 @@ impl AlertRegistry {
 
     /// Validates a vector of rule descriptors.
     ///
-    /// Ensures at most 50 rules are supplied and each rule matches a recognized prefix.
+    /// Ensures at most 50 rules are supplied, each rule matches a recognized
+    /// prefix, and no descriptor appears more than once.
     /// Exposed for testing, integration, and fuzz testing.
     /// # Errors
     /// Returns [`ContractError::TooManyRules`] if rules length exceeds 50.
     /// Returns [`ContractError::InvalidRuleDescriptor`] if any rule descriptor is invalid.
+    /// Returns [`ContractError::DuplicateRule`] if the same descriptor appears more than once.
     /// # Panics
     /// Panics if indexing into `rules` fails unexpectedly.
     pub fn validate_rules(env: &Env, rules: &Vec<String>) -> Result<(), ContractError> {
         if rules.len() > 50 {
             return Err(ContractError::TooManyRules);
         }
+        // With only two recognized descriptors, each may appear at most once.
+        let transfer = String::from_str(env, "rule:transfer");
+        let mint = String::from_str(env, "rule:mint");
+        let mut saw_transfer = false;
+        let mut saw_mint = false;
         for i in 0..rules.len() {
-            Self::validate_rule(env, &rules.get(i).unwrap())?;
+            let rule = rules.get(i).unwrap();
+            Self::validate_rule(env, &rule)?;
+            if rule == transfer {
+                if saw_transfer {
+                    return Err(ContractError::DuplicateRule);
+                }
+                saw_transfer = true;
+            } else if rule == mint {
+                if saw_mint {
+                    return Err(ContractError::DuplicateRule);
+                }
+                saw_mint = true;
+            }
         }
         Ok(())
     }

--- a/contracts/alert-registry/src/proptests.rs
+++ b/contracts/alert-registry/src/proptests.rs
@@ -41,9 +41,11 @@ fn make_str(env: &Env, s: &str) -> SorobanString {
 }
 
 fn valid_rules(env: &Env, count: usize) -> SorobanVec<SorobanString> {
-    let count = count.min(10);
+    // Only two rule descriptors exist, and `validate_rules` rejects duplicates,
+    // so a valid rule set can contain at most two entries.
+    let unique = count.min(2);
     let mut v = SorobanVec::new(env);
-    for i in 0..count {
+    for i in 0..unique {
         let rule_str = if i % 2 == 0 {
             "rule:transfer"
         } else {

--- a/contracts/alert-registry/src/tests.rs
+++ b/contracts/alert-registry/src/tests.rs
@@ -1391,6 +1391,64 @@ fn test_validate_rule_mint_and_invalid_descriptors() {
 }
 
 #[test]
+fn test_duplicate_rules_rejected() {
+    let (env, client) = setup();
+    let owner = Address::generate(&env);
+    let target = Address::generate(&env);
+
+    // Duplicate transfer rule rejected at registration.
+    assert_eq!(
+        client
+            .try_register_alert(
+                &owner,
+                &target,
+                &str(&env, "Dup Alert"),
+                &hash64(&env),
+                &vec![&env, str(&env, "rule:transfer"), str(&env, "rule:transfer")],
+            )
+            .unwrap_err()
+            .unwrap(),
+        ContractError::DuplicateRule
+    );
+
+    // Duplicate mint rule rejected at registration.
+    assert_eq!(
+        client
+            .try_register_alert(
+                &owner,
+                &target,
+                &str(&env, "Dup Mint"),
+                &hash64(&env),
+                &vec![&env, str(&env, "rule:mint"), str(&env, "rule:mint")],
+            )
+            .unwrap_err()
+            .unwrap(),
+        ContractError::DuplicateRule
+    );
+
+    // The two distinct descriptors together are still accepted.
+    let id = client.register_alert(
+        &owner,
+        &target,
+        &str(&env, "Both Rules"),
+        &hash64(&env),
+        &vec![&env, str(&env, "rule:transfer"), str(&env, "rule:mint")],
+    );
+    let cfg = client.get_alert(&owner, &id).unwrap();
+    assert_eq!(cfg.rules.len(), 2);
+
+    // Duplicates are also rejected when updating an alert's rules.
+    let dup_mint = vec![&env, str(&env, "rule:mint"), str(&env, "rule:mint")];
+    assert_eq!(
+        client
+            .try_update_alert(&owner, &id, &dup_mint, &true)
+            .unwrap_err()
+            .unwrap(),
+        ContractError::DuplicateRule
+    );
+}
+
+#[test]
 fn test_update_target_contract_moves_indices() {
     let (env, client) = setup();
     let owner = Address::generate(&env);

--- a/docs/alert-registry.md
+++ b/docs/alert-registry.md
@@ -667,6 +667,7 @@ Convenience boolean getter returning `true` if watcher-gating is currently activ
 | `DuplicateAlertId` | 11 | Internal invariant violation — an ID was already present in an index |
 | `NoPendingWebhook` | 12 | `confirm_webhook` called but no rotation is in progress |
 | `InvalidWatcherRegistry` | 13 | `set_watcher_registry` given an address that doesn't implement the `WatcherRegistry` interface |
+| `DuplicateRule` | 15 | The same rule descriptor appears more than once in `rules` |
 
 ---
 

--- a/docs/threat-model-alert-registry.md
+++ b/docs/threat-model-alert-registry.md
@@ -55,6 +55,7 @@ The contract supports:
 - **Per-Owner Active Alert Ceiling**: The admin-configurable `per_owner_alert_limit` restricts the number of active alerts any single address can create, preventing storage spam and index bloating.
 - **Rule Count and Length Bounds**: Alert rule lists are capped at a maximum of 50 rules (`ContractError::TooManyRules`), and labels are restricted to a maximum of 128 bytes (`ContractError::LabelTooLong`).
 - **Rule Descriptor Validation**: `validate_rules` parses each rule descriptor and rejects unrecognized prefixes, preventing injection of unbounded or malformed rule strings.
+- **Rule Uniqueness**: `validate_rules` rejects duplicate descriptors (`ContractError::DuplicateRule`), so a single alert cannot store redundant copies of the same rule that would waste storage and skew rule-count-based limits.
 - **Saturating Pagination**: Pagination math in `get_contract_alerts_paginated` and `get_alerts_by_owner_paginated` uses saturating arithmetic to prevent integer overflow denial of service.
 
 ### 5. Unauthorized Read Access (Watcher-Gating Attack Surface)
@@ -100,7 +101,7 @@ The contract supports:
 
 ### 5. Attacker Injects Malformed Rule Descriptors
 - **Vector**: Caller supplies strings with arbitrary binary data, invalid prefixes, or excessive rule count.
-- **Outcome**: `validate_rules` limits count to <= 50 (`ContractError::TooManyRules`) and `validate_rule` rejects any descriptor not matching recognized prefixes (`ContractError::InvalidRuleDescriptor`).
+- **Outcome**: `validate_rules` limits count to <= 50 (`ContractError::TooManyRules`), rejects duplicate descriptors (`ContractError::DuplicateRule`), and `validate_rule` rejects any descriptor not matching recognized prefixes (`ContractError::InvalidRuleDescriptor`).
 
 ### 6. Admin Address Handover
 - **Vector**: Former admin or attacker attempts to call `transfer_admin` or `set_watcher_registry` after admin role transfer.


### PR DESCRIPTION
Closes #23
Closes #24
Closes #25
Closes #26

## Description

`AlertRegistry::validate_rules` enforced the 50-rule cap and per-item descriptor validity, but never checked uniqueness — so a rule list like `["rule:transfer", "rule:transfer"]` was silently accepted and stored on-chain. That wasted storage and skewed the rule-count ceiling (an alert could nominally hold up to 50 entries while only ever meaning 2 distinct rules).

This PR adds a uniqueness check:

- **New error variant** `ContractError::DuplicateRule` (discriminant 15) returned when the same descriptor appears more than once.
- **`validate_rules`** now rejects duplicates; since only `rule:transfer` and `rule:mint` are recognized, each may appear at most once. Enforcement flows through both `register_alert` and `update_alert` (the only two entry points that call it).
- **Proptest generator** (`valid_rules`) capped at the two unique descriptors so the model-based state-machine test no longer generates rule sets that are now (correctly) invalid.
- **Tests**: new `test_duplicate_rules_rejected` covering duplicate `transfer`, duplicate `mint`, the distinct pair still accepted, and duplicates rejected via `update_alert`.
- **Docs/CHANGELOG**: error table, threat model, and CHANGELOG updated.

## Related Issue

No linked issue.

## Type of change

- Bugfix

## Checklist

- [x] My code follows the repository style
- [x] I have added relevant tests (unit / integration)
- [x] I have updated or added documentation if necessary
- [ ] All CI checks pass

## Testing notes

`cargo test`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo fmt --check` have **not** been run locally — this environment has no Rust toolchain installed. The changes were reviewed manually against existing SDK usage; CI will provide the authoritative verification.

Manual verification path:

```bash
cargo test --workspace --locked
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --all -- --check
```

## Release notes / changelog

- `validate_rules` now rejects duplicate rule descriptors with `ContractError::DuplicateRule` (previously `["rule:transfer", "rule:transfer"]` was silently accepted).
